### PR TITLE
Max El Dev in LOS

### DIFF
--- a/terragraph_planner/common/configuration/configs.py
+++ b/terragraph_planner/common/configuration/configs.py
@@ -455,9 +455,12 @@ class LOSParams(ConfigParser):
             ConfigException,
         )
         planner_assert(
-            maximum_los_distance is None
-            or (0 <= maximum_los_distance <= maximum_los_distance),
-            "Maximum/maximum LOS distance cannot be negative "
+            minimum_los_distance >= 5
+            and (
+                maximum_los_distance is None
+                or minimum_los_distance < maximum_los_distance
+            ),
+            "Minimum LOS distance cannot be less than 5m "
             "and maximum LOS distance must be larger than minimum LOS distance",
             ConfigException,
         )

--- a/terragraph_planner/common/constants.py
+++ b/terragraph_planner/common/constants.py
@@ -13,8 +13,6 @@ DEFAULT_POINTING_PRECISION = (
 EARTH_RADIUS: float = 6371000.0  # the radius of the earth, in meters
 # The upper bound for elevation deviation for valid los
 ELE_SCAN_ANGLE_LIMIT = 25
-# The additional tolerance for the elevation angle limit
-ELE_SCAN_ANGLE_TOLERANCE = 2
 FSPL_MARGIN = 92.45  # free-space path loss constant
 FULL_ROTATION_ANGLE = 360.0
 # WGS 84, aka EPSG 4326, latitude/longitude coordinate system based on the Earth's

--- a/terragraph_planner/los/base_los_validator.py
+++ b/terragraph_planner/los/base_los_validator.py
@@ -74,9 +74,9 @@ class BaseLOSValidator(ABC):
     def _passes_simple_checks(self, site1: LOSSite, site2: LOSSite) -> bool:
         """
         Performs these simple checks
-        Check 1: on the same xy coordinate
-        Check 2: on the same building
-        Check 3: out of distance range
+        Check 1: on the same building
+        Check 2: out of distance range
+        Check 3: exceeds max elevation deviation
         Check 4: intersects with the exclusion zones
         """
         if self._on_the_same_building(site1, site2):

--- a/terragraph_planner/los/constants.py
+++ b/terragraph_planner/los/constants.py
@@ -35,6 +35,16 @@ DIRECTED_LINKS: Tuple[Tuple[SiteType, SiteType], Tuple[SiteType, SiteType]] = (
     (SiteType.DN, SiteType.CN),
 )
 
+# LOS is computed in utm coordinates; distance computation has small error
+# compared with haversine distance. Due to this, for LOS computations, increase
+# the valid distance range slightly and then filter out invalid links using
+# distance computed with haversine later.
+DISTANCE_TOLERANCE_PERCENT = 0.02
+
+# Due to the distance tolerance,additional tolerance for the elevation angle
+# limit
+ELE_SCAN_ANGLE_TOLERANCE = 2
+
 # When getting altitude of corners, we need a square bound with the corner as its center
 # to search its neighbors and find a neighbor that is much higher than the neighbor's
 # neighbor. HALF_SIDE_LENGTH_FOR_ALTITUDE_SEARCH (in metres) is the half of the side length

--- a/terragraph_planner/los/core.py
+++ b/terragraph_planner/los/core.py
@@ -414,6 +414,7 @@ def build_candidate_topology(
         confidence_dict,
         los_params.device_list,
         device_pair_to_max_los_dist,
+        los_params.minimum_los_distance,
     )
     logger.info("Completed constructing the topology.")
     return topology

--- a/terragraph_planner/los/cylindrical_los_validator.py
+++ b/terragraph_planner/los/cylindrical_los_validator.py
@@ -36,6 +36,7 @@ class CylindricalLOSValidator(BaseLOSValidator):
         surface_elevation: Optional[Elevation],
         max_los_distance: float,
         min_los_distance: float,
+        max_el_dev: float,
         fresnel_radius: float,
         exclusion_zones: List[Polygon],
         los_confidence_threshold: float,
@@ -44,6 +45,7 @@ class CylindricalLOSValidator(BaseLOSValidator):
             surface_elevation,
             max_los_distance,
             min_los_distance,
+            max_el_dev,
             exclusion_zones,
             los_confidence_threshold,
         )

--- a/terragraph_planner/los/ellipsoidal_los_validator.py
+++ b/terragraph_planner/los/ellipsoidal_los_validator.py
@@ -26,6 +26,7 @@ class EllipsoidalLOSValidator(BaseLOSValidator):
         surface_elevation: Optional[Elevation],
         max_los_distance: float,
         min_los_distance: float,
+        max_el_dev: float,
         frequency_mhz: float,
         exclusion_zones: List[Polygon],
         los_confidence_threshold: float,
@@ -34,6 +35,7 @@ class EllipsoidalLOSValidator(BaseLOSValidator):
             surface_elevation,
             max_los_distance,
             min_los_distance,
+            max_el_dev,
             exclusion_zones,
             los_confidence_threshold,
         )

--- a/terragraph_planner/los/helper.py
+++ b/terragraph_planner/los/helper.py
@@ -31,7 +31,6 @@ from terragraph_planner.common.configuration.enums import (
 )
 from terragraph_planner.common.constants import (
     ELE_SCAN_ANGLE_LIMIT,
-    ELE_SCAN_ANGLE_TOLERANCE,
     LOWER_BOUND_FOR_LOS_DISTANCE,
     UPPER_BOUND_FOR_LOS_DISTANCE,
 )
@@ -67,6 +66,8 @@ from terragraph_planner.los.constants import (
     BI_DIRECTIONAL_LINKS,
     BUILDING_HEIGHT_THRESHOLD,
     DIRECTED_LINKS,
+    DISTANCE_TOLERANCE_PERCENT,
+    ELE_SCAN_ANGLE_TOLERANCE,
 )
 from terragraph_planner.los.cylindrical_los_validator import (
     CylindricalLOSValidator,
@@ -546,8 +547,9 @@ def compute_los_batch(
     if use_ellipsoidal_los_model:
         los_validator = EllipsoidalLOSValidator(
             surface_elevation,
-            max_los_distance,
-            min_los_distance,
+            max_los_distance * (1 + DISTANCE_TOLERANCE_PERCENT),
+            min_los_distance * (1 - DISTANCE_TOLERANCE_PERCENT),
+            ELE_SCAN_ANGLE_LIMIT + ELE_SCAN_ANGLE_TOLERANCE,
             carrier_frequency,
             exclusion_zones,
             los_confidence_threshold,
@@ -555,8 +557,9 @@ def compute_los_batch(
     else:
         los_validator = CylindricalLOSValidator(
             surface_elevation,
-            max_los_distance,
-            min_los_distance,
+            max_los_distance * (1 + DISTANCE_TOLERANCE_PERCENT),
+            min_los_distance * (1 - DISTANCE_TOLERANCE_PERCENT),
+            ELE_SCAN_ANGLE_LIMIT + ELE_SCAN_ANGLE_TOLERANCE,
             fresnel_radius,
             exclusion_zones,
             los_confidence_threshold,
@@ -827,6 +830,7 @@ def construct_topology_from_los_result(
     confidence_dict: Dict[Tuple[int, int], float],
     device_list: List[DeviceData],
     device_pair_to_max_los_dist: Dict[Tuple[str, str], int],
+    min_los_dist: int,
 ) -> Topology:
     """
     Construct a Topology instance for candidate graph from LOS result.
@@ -861,6 +865,7 @@ def construct_topology_from_los_result(
         site_map,
         confidence_dict,
         device_pair_to_max_los_dist,
+        min_los_dist,
     )
 
 
@@ -920,6 +925,7 @@ def add_links_to_topology(
     site_map: Dict[int, List[Site]],
     confidence_dict: Dict[Tuple[int, int], float],
     device_pair_to_max_los_dist: Dict[Tuple[str, str], int],
+    min_los_dist: int,
 ) -> Topology:
     """
     Called by construct_topology_from_los_result, this function is to add links to
@@ -945,16 +951,15 @@ def add_links_to_topology(
                         ],
                     )
                     if (
-                        link.distance
-                        < device_pair_to_max_los_dist[
+                        min_los_dist
+                        <= link.distance
+                        <= device_pair_to_max_los_dist[
                             (
                                 tx_site.device.device_sku,
                                 rx_site.device.device_sku,
                             )
                         ]
-                        and link.el_dev
-                        < ELE_SCAN_ANGLE_LIMIT
-                        + ELE_SCAN_ANGLE_TOLERANCE  # additional tolerance
+                        and link.el_dev <= ELE_SCAN_ANGLE_LIMIT
                     ):
                         topology.add_link(link)
     return topology

--- a/terragraph_planner/los/helper.py
+++ b/terragraph_planner/los/helper.py
@@ -847,6 +847,8 @@ def construct_topology_from_los_result(
     A list of device data.
     @param device_pair_to_max_los_dist
     A dict mapping a pair of device SKUs to the max los distance.
+    @param min_los_dist
+    An int for the min los distance.
     @return
     A Topology representing the candidate graph.
     """

--- a/terragraph_planner/los/test/test_base_los_validator.py
+++ b/terragraph_planner/los/test/test_base_los_validator.py
@@ -42,7 +42,9 @@ class TestBaseLOSValidator(TestCase):
         )
 
     def test_same_x_y_coordinate(self) -> None:
-        base_los_validator = MockBaseLOSValidator(self.elevation, 5, 1, [], 1)
+        base_los_validator = MockBaseLOSValidator(
+            self.elevation, 5, 1, 89, [], 1
+        )
         self.assertEqual(
             base_los_validator._passes_simple_checks(
                 build_los_site_for_los_test(
@@ -64,7 +66,9 @@ class TestBaseLOSValidator(TestCase):
         )
 
     def test_on_the_same_building(self) -> None:
-        base_los_validator = MockBaseLOSValidator(self.elevation, 5, 1, [], 1)
+        base_los_validator = MockBaseLOSValidator(
+            self.elevation, 5, 1, 25, [], 1
+        )
         self.assertEqual(
             base_los_validator._on_the_same_building(
                 build_los_site_for_los_test(
@@ -86,30 +90,61 @@ class TestBaseLOSValidator(TestCase):
         )
 
     def test_out_of_distance_range(self) -> None:
-        base_los_validator = MockBaseLOSValidator(self.elevation, 2, 1, [], 1)
-        self.assertEqual(
-            base_los_validator._los_out_of_distance_range(
-                build_los_site_for_los_test(
-                    0.5,
-                    0.5,
-                    10,
-                    location_type=LocationType.ROOFTOP,
-                    building_id=1,
-                ),
-                build_los_site_for_los_test(
-                    2.5,
-                    2.5,
-                    9,
-                    location_type=LocationType.ROOFTOP,
-                    building_id=2,
-                ),
+        base_los_validator = MockBaseLOSValidator(
+            self.elevation, 2, 1, 25, [], 1
+        )
+        distance = base_los_validator._comp_los_distance(
+            build_los_site_for_los_test(
+                0.5,
+                0.5,
+                10,
+                location_type=LocationType.ROOFTOP,
+                building_id=1,
             ),
-            True,
+            build_los_site_for_los_test(
+                2.5,
+                2.5,
+                9,
+                location_type=LocationType.ROOFTOP,
+                building_id=2,
+            ),
+        )
+        self.assertEqual(
+            base_los_validator._los_out_of_distance_range(distance), True
+        )
+
+    def test_large_el_dev(self) -> None:
+        base_los_validator = MockBaseLOSValidator(
+            self.elevation, 50, 1, 25, [], 1
+        )
+        distance = base_los_validator._comp_los_distance(
+            build_los_site_for_los_test(
+                2.5,
+                2.5,
+                20,
+                location_type=LocationType.ROOFTOP,
+                building_id=3,
+            ),
+            build_los_site_for_los_test(
+                6.5,
+                2.5,
+                10,
+                location_type=LocationType.ROOFTOP,
+                building_id=1,
+            ),
+        )
+        self.assertEqual(
+            base_los_validator._los_exceed_max_el_dev(distance, 20, 10), True
         )
 
     def test_intersects_with_exclusion_zone(self) -> None:
         base_los_validator = MockBaseLOSValidator(
-            self.elevation, 5, 1, [Polygon([(1, 1), (2, 1), (2, 2), (1, 2)])], 1
+            self.elevation,
+            5,
+            1,
+            25,
+            [Polygon([(1, 1), (2, 1), (2, 2), (1, 2)])],
+            1,
         )
         self.assertEqual(
             base_los_validator._los_intersects_with_exclusion_zones(
@@ -121,7 +156,12 @@ class TestBaseLOSValidator(TestCase):
 
     def test_passes_simple_checks(self) -> None:
         base_los_validator = MockBaseLOSValidator(
-            self.elevation, 5, 1, [Polygon([(4, 1), (5, 1), (5, 2), (4, 2)])], 1
+            self.elevation,
+            5,
+            1,
+            25,
+            [Polygon([(4, 1), (5, 1), (5, 2), (4, 2)])],
+            1,
         )
         self.assertEqual(
             base_los_validator._passes_simple_checks(
@@ -132,7 +172,9 @@ class TestBaseLOSValidator(TestCase):
         )
 
     def test_get_four_corners_of_rectangle(self) -> None:
-        base_los_validator = MockBaseLOSValidator(self.elevation, 5, 1, [], 1)
+        base_los_validator = MockBaseLOSValidator(
+            self.elevation, 5, 1, 25, [], 1
+        )
         a, b, c, d = base_los_validator._get_four_corners_of_rectangle(
             0.5, 7, 3, 3, 1
         )
@@ -147,7 +189,9 @@ class TestBaseLOSValidator(TestCase):
         self.assertAlmostEqual(d[1], 2.47000106)
 
     def test_get_four_corners_of_rectangle_x_alinged(self) -> None:
-        base_los_validator = MockBaseLOSValidator(self.elevation, 5, 1, [], 1)
+        base_los_validator = MockBaseLOSValidator(
+            self.elevation, 5, 1, 25, [], 1
+        )
         a, b, c, d = base_los_validator._get_four_corners_of_rectangle(
             3, 7, 3, 3, 1
         )
@@ -162,7 +206,9 @@ class TestBaseLOSValidator(TestCase):
         self.assertEqual(d[1], 3)
 
     def test_get_four_corners_of_rectangle_y_alinged(self) -> None:
-        base_los_validator = MockBaseLOSValidator(self.elevation, 5, 1, [], 1)
+        base_los_validator = MockBaseLOSValidator(
+            self.elevation, 5, 1, 25, [], 1
+        )
         a, b, c, d = base_los_validator._get_four_corners_of_rectangle(
             0.5, 3, 3, 3, 1
         )

--- a/terragraph_planner/los/test/test_core.py
+++ b/terragraph_planner/los/test/test_core.py
@@ -160,7 +160,7 @@ class TestCore(TestCase):
             None,
             [],
             100,
-            0,
+            1,
             1,
             True,
             1,

--- a/terragraph_planner/los/test/test_cylindrical_los_validator.py
+++ b/terragraph_planner/los/test/test_cylindrical_los_validator.py
@@ -360,7 +360,9 @@ class TestCylindricalLOSValidator(TestCase):
                 grid, ax, ay, az, bx, by, bz, b_len_2d_sq, b_len_2d, b_len_3d_sq
             )
 
-        los_validator = CylindricalLOSValidator(None, 200.0, 0.0, 1.0, [], 1.0)
+        los_validator = CylindricalLOSValidator(
+            None, 200.0, 1.0, 25, 1.0, [], 1.0
+        )
         ax, ay, az = 1, 1, 1
         bx, by, bz = 2, 2, 2
         b_len_2d_sq = bx * bx + by * by

--- a/terragraph_planner/los/test/test_cylindrical_los_validator.py
+++ b/terragraph_planner/los/test/test_cylindrical_los_validator.py
@@ -41,7 +41,7 @@ class TestCylindricalLOSValidator(TestCase):
 
     def test_on_the_same_building(self) -> None:
         los_validator = CylindricalLOSValidator(
-            self.elevation, 5, 1, 0.4, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
+            self.elevation, 5, 1, 0.4, 25, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
         )
         self.assertEqual(
             los_validator.compute_confidence(
@@ -65,7 +65,7 @@ class TestCylindricalLOSValidator(TestCase):
 
     def test_out_of_distance_range(self) -> None:
         los_validator = CylindricalLOSValidator(
-            self.elevation, 2, 1, 0.4, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
+            self.elevation, 2, 1, 25, 0.4, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
         )
         self.assertEqual(
             los_validator.compute_confidence(
@@ -75,11 +75,24 @@ class TestCylindricalLOSValidator(TestCase):
             0.0,
         )
 
+    def test_large_el_dev(self) -> None:
+        los_validator = CylindricalLOSValidator(
+            self.elevation, 50, 1, 25, 0.4, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
+        )
+        self.assertEqual(
+            los_validator.compute_confidence(
+                build_los_site_for_los_test(2.5, 2.5, 20),
+                build_los_site_for_los_test(6.5, 2.5, 10),
+            ),
+            0.0,
+        )
+
     def test_intersects_with_exclusion_zone(self) -> None:
         los_validator = CylindricalLOSValidator(
             self.elevation,
             5,
             1,
+            25,
             0.4,
             [Polygon([(1, 1), (2, 1), (2, 2), (1, 2)])],
             DEFAULT_LOS_CONFIDENCE_THRESHOLD,
@@ -94,7 +107,7 @@ class TestCylindricalLOSValidator(TestCase):
 
     def test_grid_higher_than_sites(self) -> None:
         los_validator = CylindricalLOSValidator(
-            self.elevation, 5, 1, 0.4, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
+            self.elevation, 5, 1, 25, 0.4, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
         )
         self.assertEqual(
             los_validator.compute_confidence(
@@ -106,7 +119,7 @@ class TestCylindricalLOSValidator(TestCase):
 
     def test_a_clear_los(self) -> None:
         los_validator = CylindricalLOSValidator(
-            self.elevation, 5, 1, 0.4, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
+            self.elevation, 5, 1, 25, 0.4, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
         )
         self.assertEqual(
             los_validator.compute_confidence(
@@ -118,7 +131,7 @@ class TestCylindricalLOSValidator(TestCase):
 
     def test_grid_higher_than_max_top_view_plane(self) -> None:
         los_validator = CylindricalLOSValidator(
-            self.elevation, 5, 1, 0.4, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
+            self.elevation, 5, 1, 25, 0.4, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
         )
         self.assertEqual(
             los_validator.compute_confidence(
@@ -130,7 +143,7 @@ class TestCylindricalLOSValidator(TestCase):
 
     def test_grid_center_within_utm_zone(self) -> None:
         los_validator = CylindricalLOSValidator(
-            self.elevation, 5, 1, 0.4, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
+            self.elevation, 5, 1, 25, 0.4, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
         )
         self.assertEqual(
             los_validator.compute_confidence(
@@ -161,7 +174,7 @@ class TestCylindricalLOSValidator(TestCase):
             None,
         )
         los_validator = CylindricalLOSValidator(
-            elevation, 5, 1, 1, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
+            elevation, 5, 1, 25, 1, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
         )
         # The LOS line is below the max_top_view_plane, so the minimal distance
         # is from point (x.5, 3.5, z) to the LOS center, where x = 1,2,3,4, and z < 5
@@ -195,7 +208,7 @@ class TestCylindricalLOSValidator(TestCase):
 
     def test_point_within_rectangle(self) -> None:
         los_validator = CylindricalLOSValidator(
-            self.elevation, 5, 1, 1, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
+            self.elevation, 5, 1, 25, 1, [], DEFAULT_LOS_CONFIDENCE_THRESHOLD
         )
         utm_x1, utm_y1 = (1, 1)
         utm_x2, utm_y2 = (3, 0.5)
@@ -237,7 +250,7 @@ class TestCylindricalLOSValidator(TestCase):
             spatial_reference=self.spatial_reference,
             collection_time=None,
         )
-        los_validator = CylindricalLOSValidator(elevation, 5, 1, 2, [], 1.0)
+        los_validator = CylindricalLOSValidator(elevation, 5, 1, 25, 2, [], 1.0)
 
         # Obstructions with height 3 will cause confidence level to be 0 but they
         # are not within the 2D projection and are filtered out
@@ -268,7 +281,7 @@ class TestCylindricalLOSValidator(TestCase):
             spatial_reference=self.spatial_reference,
             collection_time=None,
         )
-        los_validator = CylindricalLOSValidator(elevation, 5, 1, 2, [], 1.0)
+        los_validator = CylindricalLOSValidator(elevation, 5, 1, 25, 2, [], 1.0)
 
         # Obstructions with height 3 will cause confidence level to be 0 but they
         # are not within the 2D spatial_reference and are filtered out
@@ -300,7 +313,7 @@ class TestCylindricalLOSValidator(TestCase):
             spatial_reference=self.spatial_reference,
             collection_time=None,
         )
-        los_validator = CylindricalLOSValidator(elevation, 5, 1, 1, [], 1.0)
+        los_validator = CylindricalLOSValidator(elevation, 5, 1, 25, 1, [], 1.0)
 
         self.assertEqual(
             los_validator.compute_confidence(
@@ -331,7 +344,7 @@ class TestCylindricalLOSValidator(TestCase):
             spatial_reference=self.spatial_reference,
             collection_time=None,
         )
-        los_validator = CylindricalLOSValidator(elevation, 5, 1, 2, [], 1.0)
+        los_validator = CylindricalLOSValidator(elevation, 5, 1, 25, 2, [], 1.0)
 
         self.assertEqual(
             los_validator.compute_confidence(

--- a/terragraph_planner/los/test/test_ellipsoidal_los_validator.py
+++ b/terragraph_planner/los/test/test_ellipsoidal_los_validator.py
@@ -42,6 +42,7 @@ class TestEllipsoidalLOSValidator(TestCase):
             self.elevation,
             5,
             1,
+            25,
             DEFAULT_CARRIER_FREQUENCY,
             [],
             DEFAULT_LOS_CONFIDENCE_THRESHOLD,
@@ -72,6 +73,7 @@ class TestEllipsoidalLOSValidator(TestCase):
             self.elevation,
             2,
             1,
+            25,
             DEFAULT_CARRIER_FREQUENCY,
             [],
             DEFAULT_LOS_CONFIDENCE_THRESHOLD,
@@ -85,11 +87,30 @@ class TestEllipsoidalLOSValidator(TestCase):
             0.0,
         )
 
+    def test_large_el_dev(self) -> None:
+        los_validator = EllipsoidalLOSValidator(
+            self.elevation,
+            50,
+            1,
+            25,
+            DEFAULT_CARRIER_FREQUENCY,
+            [],
+            DEFAULT_LOS_CONFIDENCE_THRESHOLD,
+        )
+        self.assertEqual(
+            los_validator.compute_confidence(
+                build_los_site_for_los_test(2.5, 2.5, 20),
+                build_los_site_for_los_test(6.5, 2.5, 10),
+            ),
+            0.0,
+        )
+
     def test_intersects_with_exclusion_zone(self) -> None:
         los_validator = EllipsoidalLOSValidator(
             self.elevation,
             5,
             1,
+            25,
             DEFAULT_CARRIER_FREQUENCY,
             [Polygon([(1, 1), (2, 1), (2, 2), (1, 2)])],
             DEFAULT_LOS_CONFIDENCE_THRESHOLD,
@@ -107,6 +128,7 @@ class TestEllipsoidalLOSValidator(TestCase):
             self.elevation,
             5,
             1,
+            25,
             DEFAULT_CARRIER_FREQUENCY,
             [],
             DEFAULT_LOS_CONFIDENCE_THRESHOLD,
@@ -125,6 +147,7 @@ class TestEllipsoidalLOSValidator(TestCase):
             self.elevation,
             5,
             1,
+            25,
             DEFAULT_CARRIER_FREQUENCY,
             [],
             DEFAULT_LOS_CONFIDENCE_THRESHOLD,
@@ -150,6 +173,7 @@ class TestEllipsoidalLOSValidator(TestCase):
             self.elevation,
             5,
             1,
+            25,
             DEFAULT_CARRIER_FREQUENCY,
             [],
             DEFAULT_LOS_CONFIDENCE_THRESHOLD,
@@ -185,6 +209,7 @@ class TestEllipsoidalLOSValidator(TestCase):
             elevation,
             5,
             1,
+            25,
             DEFAULT_CARRIER_FREQUENCY,
             [],
             DEFAULT_LOS_CONFIDENCE_THRESHOLD,
@@ -214,6 +239,7 @@ class TestEllipsoidalLOSValidator(TestCase):
             elevation,
             5,
             1,
+            25,
             DEFAULT_CARRIER_FREQUENCY,
             [],
             DEFAULT_LOS_CONFIDENCE_THRESHOLD,
@@ -251,6 +277,7 @@ class TestEllipsoidalLOSValidator(TestCase):
             elevation,
             5,
             1,
+            45,
             DEFAULT_CARRIER_FREQUENCY,
             [],
             DEFAULT_LOS_CONFIDENCE_THRESHOLD,
@@ -288,6 +315,7 @@ class TestEllipsoidalLOSValidator(TestCase):
             elevation,
             5,
             1,
+            45,
             DEFAULT_CARRIER_FREQUENCY,
             [],
             DEFAULT_LOS_CONFIDENCE_THRESHOLD,
@@ -321,7 +349,7 @@ class TestEllipsoidalLOSValidator(TestCase):
             None,
         )
         los_validator = EllipsoidalLOSValidator(
-            elevation, 5, 1, DEFAULT_CARRIER_FREQUENCY, [], 0.6
+            elevation, 5, 1, 25, DEFAULT_CARRIER_FREQUENCY, [], 0.6
         )
 
         # point at (0.5, 0.1, 5) is the closest obstruction that creates the smallest fresnel zone
@@ -352,7 +380,7 @@ class TestEllipsoidalLOSValidator(TestCase):
             None,
         )
         los_validator = EllipsoidalLOSValidator(
-            elevation, 5, 1, DEFAULT_CARRIER_FREQUENCY, [], 0.6
+            elevation, 5, 1, 75, DEFAULT_CARRIER_FREQUENCY, [], 0.6
         )
 
         # point at (0.1, 0.2, 9) is the closest obstruction that creates the smallest fresnel zone
@@ -383,7 +411,7 @@ class TestEllipsoidalLOSValidator(TestCase):
             None,
         )
         los_validator = EllipsoidalLOSValidator(
-            elevation, 5, 1, DEFAULT_CARRIER_FREQUENCY, [], 0.6
+            elevation, 5, 1, 75, DEFAULT_CARRIER_FREQUENCY, [], 0.6
         )
 
         # point at (0.9, 0.2, 2.3) is the closest obstruction that creates the smallest fresnel zone

--- a/terragraph_planner/los/test/test_helper.py
+++ b/terragraph_planner/los/test/test_helper.py
@@ -743,6 +743,7 @@ class TestConstructTopologyFromLOSResult(TestCase):
             (self.device1.device_sku, self.device0.device_sku): 3,
             (self.device1.device_sku, self.device1.device_sku): 4,
         }
+        self.min_los_distance = 0
 
     def validate_topology(
         self,
@@ -776,6 +777,7 @@ class TestConstructTopologyFromLOSResult(TestCase):
             confidence_dict=self.confidence_dict,
             device_list=[self.device0, self.device1],
             device_pair_to_max_los_dist=self.device_pair_to_max_los_dist,
+            min_los_dist=self.min_los_distance,
         )
         expected_links = {
             "0_device1-4_device1",
@@ -814,6 +816,7 @@ class TestConstructTopologyFromLOSResult(TestCase):
             confidence_dict=self.confidence_dict,
             device_list=[self.device0, self.device1],
             device_pair_to_max_los_dist=self.device_pair_to_max_los_dist,
+            min_los_dist=self.min_los_distance,
         )
         expected_links = {
             "0_device1-4_device1",
@@ -842,6 +845,7 @@ class TestConstructTopologyFromLOSResult(TestCase):
             confidence_dict=self.confidence_dict,
             device_list=[self.device0, self.device1],
             device_pair_to_max_los_dist=self.device_pair_to_max_los_dist,
+            min_los_dist=self.min_los_distance,
         )
         expected_links = {
             "0_device1-4_device1",
@@ -881,6 +885,7 @@ class TestConstructTopologyFromLOSResult(TestCase):
             confidence_dict=self.confidence_dict,
             device_list=[self.device0, self.device1],
             device_pair_to_max_los_dist=self.device_pair_to_max_los_dist,
+            min_los_dist=self.min_los_distance,
         )
         # The first two sites will be connected. The third site exceeds max
         # distance and the fourth site exceeds elevation deviation


### PR DESCRIPTION
## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

## Description

Add max elevation deviation check to LOS simple checks. Same x,y is covered by this, but this is more general.

Also, add some extra tolerance for max/min los distance and for max elevation due to differences between utm distance computation and haversine distance (experimentally seems to be about 1%).

Force min LOS distance to be greater than 5m. Otherwise, LOS can have degeneracy/precision errors for tiny LOS distances.

## Test Plan

Add unit tests