### PR TITLE
Azimuthual Deviation with Sign

### DIFF
--- a/terragraph_planner/common/geos.py
+++ b/terragraph_planner/common/geos.py
@@ -15,6 +15,7 @@ from terragraph_planner.common.constants import (
     FULL_ROTATION_ANGLE,
     LAT_LON_EPSG,
     LAT_LON_TO_GEO_HASH_PRECISION,
+    STRAIGHT_ANGLE,
 )
 from terragraph_planner.common.exceptions import (
     GeoSystemException,
@@ -184,10 +185,16 @@ def _longitude_to_utm_zone(longitude: float) -> int:
 
 def angle_delta(angle1: float, angle2: float) -> float:
     """
-    Difference between two angles (accounting for 360 degree periodicity)
+    Computes angle1 - angle2 with result in (-180, 180].
     """
-    dev = abs(angle1 - angle2)
-    return min(dev, FULL_ROTATION_ANGLE - dev)
+    dev = angle1 - angle2
+    return (
+        dev - FULL_ROTATION_ANGLE
+        if dev > STRAIGHT_ANGLE
+        else dev + FULL_ROTATION_ANGLE
+        if dev <= -STRAIGHT_ANGLE
+        else dev
+    )
 
 
 def lat_lon_to_utm_epsg(latitutde: float, longitude: float) -> int:

--- a/terragraph_planner/common/rf/link_budget_calculator.py
+++ b/terragraph_planner/common/rf/link_budget_calculator.py
@@ -278,7 +278,8 @@ def get_fspl_based_net_gain(
     rx_radio_pattern_data: Optional[Union[AntennaPatternData, ScanPatternData]],
     tx_deviation: float,
     rx_deviation: float,
-    el_deviation: float,
+    tx_el_deviation: float,
+    rx_el_deviation: float,
 ) -> float:
     """
     Compute received net gain (dBi) at the receiver assuming that:
@@ -294,7 +295,8 @@ def get_fspl_based_net_gain(
     @param rx_radio_pattern_data: The antenna/scan pattern data for the rx radio.
     @param tx_deviation: Horizontal deviation from boresight in tx direction (degrees)
     @param rx_deviation: Horizontal deviation from boresight in rx direction (degrees)
-    @param el_deviation: Vertical deviation from boresight in rx direction (degrees)
+    @param tx_el_deviation: Vertical deviation from horizontal plane in tx direction (degrees)
+    @param rx_el_deviation: Vertical deviation from horizontal plane rx rx direction (degrees)
     """
 
     # FSPL (dB) when link distance d (kms) and frequency (GHz) is given.
@@ -315,14 +317,14 @@ def get_fspl_based_net_gain(
         tx_sector_params.tx_diversity_gain,
         tx_radio_pattern_data,
         tx_deviation,
-        el_deviation,
+        tx_el_deviation,
     )
     rx_gain = extract_gain_from_radio_pattern(
         rx_sector_params.antenna_boresight_gain,
         rx_sector_params.rx_diversity_gain,
         rx_radio_pattern_data,
         rx_deviation,
-        el_deviation,
+        rx_el_deviation,
     )
     rain_loss = compute_rain_loss(
         dist_km=dist_km,
@@ -583,7 +585,8 @@ def fspl_based_estimation(
         rx_radio_pattern_data=rx_scan_pattern_data,
         tx_deviation=tx_deviation,
         rx_deviation=rx_deviation,
-        el_deviation=el_deviation,
+        tx_el_deviation=el_deviation,
+        rx_el_deviation=-el_deviation,
     )
     np_dbm = get_noise_power(rx_sector_params)
     link_budget = get_measurements_from_tx_power(

--- a/terragraph_planner/common/rf/test/test_link_budget_calculator.py
+++ b/terragraph_planner/common/rf/test/test_link_budget_calculator.py
@@ -231,6 +231,7 @@ class TestFSPLBasedRSLValue(unittest.TestCase):
             0,
             0,
             0,
+            0,
         )
         self.assertAlmostEqual(expected_net_gain, computed_net_gain)
 
@@ -305,6 +306,7 @@ class TestFSPLBasedRSLValue(unittest.TestCase):
             0,
             0,
             0,
+            0,
         )
         self.assertAlmostEqual(expected_net_gain, computed_net_gain)
 
@@ -360,6 +362,7 @@ class TestLinkMCS(unittest.TestCase):
                 antenna_pattern_data,
                 None,
                 None,
+                0,
                 0,
                 0,
                 0,
@@ -480,6 +483,7 @@ class TestLinkTxPower(unittest.TestCase):
                 antenna_pattern_data,
                 None,
                 None,
+                0,
                 0,
                 0,
                 0,

--- a/terragraph_planner/common/topology_models/link.py
+++ b/terragraph_planner/common/topology_models/link.py
@@ -22,6 +22,7 @@ from terragraph_planner.common.exceptions import (
     planner_assert,
 )
 from terragraph_planner.common.geos import (
+    angle_delta,
     bearing_in_degrees,
     haversine_distance,
 )
@@ -244,16 +245,14 @@ class Link:
         if self.link_type == LinkType.ETHERNET or self.tx_sector is None:
             return None
         tx_sector_az = none_throws(self.tx_sector).ant_azimuth
-        tx_dev = abs(self.tx_beam_azimuth - tx_sector_az)
-        return min(tx_dev, FULL_ROTATION_ANGLE - tx_dev)
+        return angle_delta(self.tx_beam_azimuth, tx_sector_az)
 
     @property
     def rx_dev(self) -> Optional[float]:
         if self.link_type == LinkType.ETHERNET or self.rx_sector is None:
             return None
         rx_sector_az = none_throws(self.rx_sector).ant_azimuth
-        rx_dev = abs(self.rx_beam_azimuth - rx_sector_az)
-        return min(rx_dev, FULL_ROTATION_ANGLE - rx_dev)
+        return angle_delta(self.rx_beam_azimuth, rx_sector_az)
 
     @property
     def el_dev(self) -> float:

--- a/terragraph_planner/common/topology_models/test/test_link.py
+++ b/terragraph_planner/common/topology_models/test/test_link.py
@@ -247,7 +247,7 @@ class TestDeviationAngles(TestCase):
 
         self.assertAlmostEqual(
             self.topology.links["DN1-DN4"].tx_dev,
-            abs(
+            (
                 self.topology.links["DN1-DN4"].tx_beam_azimuth
                 - self.topology.links["DN1-POP5"].tx_beam_azimuth
             )
@@ -273,10 +273,10 @@ class TestDeviationAngles(TestCase):
         angle, _ = law_of_cosines_spherical(lat0, lon0, lat1, lon1, lat2, lon2)
 
         self.assertAlmostEqual(
-            self.topology.links["DN1-DN4"].tx_dev, angle / 2, delta=0.1
+            self.topology.links["DN1-DN4"].tx_dev, -angle / 2, delta=0.1
         )
         self.assertAlmostEqual(
-            self.topology.links["DN4-DN1"].rx_dev, angle / 2, delta=0.1
+            self.topology.links["DN4-DN1"].rx_dev, -angle / 2, delta=0.1
         )
         self.assertAlmostEqual(
             self.topology.links["DN1-POP5"].tx_dev, angle / 2, delta=0.1
@@ -328,13 +328,13 @@ class TestDeviationAngles(TestCase):
         # be between (0, 10) and not (350, 355).
         self.assertGreater(links[0].tx_beam_azimuth, 355)
         self.assertLess(links[0].tx_beam_azimuth, 360)
-        self.assertGreater(links[0].tx_dev, 0)
-        self.assertLess(links[0].tx_dev, 10)
+        self.assertLess(links[0].tx_dev, 0)
+        self.assertGreater(links[0].tx_dev, -10)
 
         self.assertGreater(links[1].rx_beam_azimuth, 355)
         self.assertLess(links[1].rx_beam_azimuth, 360)
-        self.assertGreater(links[1].rx_dev, 0)
-        self.assertLess(links[1].rx_dev, 10)
+        self.assertLess(links[1].rx_dev, 0)
+        self.assertGreater(links[1].rx_dev, -10)
 
     def test_elevation_deviation(self) -> None:
         site1 = SampleSite(

--- a/terragraph_planner/optimization/ilp_models/interference_optimization.py
+++ b/terragraph_planner/optimization/ilp_models/interference_optimization.py
@@ -712,7 +712,7 @@ class MinInterferenceNetwork(NetworkOptimization):
                     self.link_to_azimuth[(tx_site, rx_site)][1]
                 )
                 in_link_azimuth = none_throws(self.link_to_azimuth[in_link][1])
-                angle_between = angle_delta(in_link_azimuth, link_azimuth)
+                angle_between = abs(angle_delta(in_link_azimuth, link_azimuth))
                 if (
                     angle_between
                     >= self.horizontal_scan_range[rx_site] / 2

--- a/terragraph_planner/optimization/ilp_models/test/test_interference_optimization.py
+++ b/terragraph_planner/optimization/ilp_models/test/test_interference_optimization.py
@@ -262,9 +262,11 @@ class TestInterferenceOptimization(TestCase):
         for site_id in ["DN3", "DN4", "POP5", "POP6", "CN7", "CN8"]:
             topology.sites[site_id].status_type = StatusType.PROPOSED
 
-        angle_between = angle_delta(
-            topology.links["DN4-CN8"].rx_beam_azimuth,
-            topology.links["DN3-CN8"].rx_beam_azimuth,
+        angle_between = abs(
+            angle_delta(
+                topology.links["DN4-CN8"].rx_beam_azimuth,
+                topology.links["DN3-CN8"].rx_beam_azimuth,
+            )
         )
 
         # Set CN scan range to just large enough to include both links

--- a/terragraph_planner/optimization/test/test_topology_interference.py
+++ b/terragraph_planner/optimization/test/test_topology_interference.py
@@ -205,12 +205,12 @@ class TestInterferenceComputation(TestCase):
                     tx_interfering_link = topology.links[tx_interfering_link_id]
 
                     tx_dev = angle_delta(
-                        none_throws(tx_interfering_link.tx_dev),
                         none_throws(interfering_path.tx_dev),
+                        none_throws(tx_interfering_link.tx_dev),
                     )
                     rx_dev = angle_delta(
-                        none_throws(rx_interfered_link.rx_dev),
                         none_throws(interfering_path.rx_dev),
+                        none_throws(rx_interfered_link.rx_dev),
                     )
 
                     net_gain = _compute_link_interference_net_gain(

--- a/terragraph_planner/optimization/test/test_topology_interference.py
+++ b/terragraph_planner/optimization/test/test_topology_interference.py
@@ -212,9 +212,15 @@ class TestInterferenceComputation(TestCase):
                         none_throws(interfering_path.rx_dev),
                         none_throws(rx_interfered_link.rx_dev),
                     )
+                    tx_el_dev = angle_delta(
+                        interfering_path.el_dev, tx_interfering_link.el_dev
+                    )
+                    rx_el_dev = -angle_delta(
+                        interfering_path.el_dev, rx_interfered_link.el_dev
+                    )
 
                     net_gain = _compute_link_interference_net_gain(
-                        interfering_path, tx_dev, rx_dev
+                        interfering_path, tx_dev, rx_dev, tx_el_dev, rx_el_dev
                     )
                     interference = log_to_linear(
                         get_fspl_based_rsl(

--- a/terragraph_planner/optimization/test/test_topology_preparation.py
+++ b/terragraph_planner/optimization/test/test_topology_preparation.py
@@ -728,10 +728,10 @@ class TestFindBestEquidistantSectors(TestCase):
         self.assertEqual(len(nodes), 4)
         for node in nodes:
             self.assertEqual(len(node), 1)
-        self.assertEqual(angle_delta(nodes[0][0], nodes[1][0]), 90)
-        self.assertEqual(angle_delta(nodes[1][0], nodes[2][0]), 90)
-        self.assertEqual(angle_delta(nodes[2][0], nodes[3][0]), 90)
-        self.assertEqual(angle_delta(nodes[3][0], nodes[0][0]), 90)
+        self.assertEqual(abs(angle_delta(nodes[0][0], nodes[1][0])), 90)
+        self.assertEqual(abs(angle_delta(nodes[1][0], nodes[2][0])), 90)
+        self.assertEqual(abs(angle_delta(nodes[2][0], nodes[3][0])), 90)
+        self.assertEqual(abs(angle_delta(nodes[3][0], nodes[0][0])), 90)
 
     def test_find_equidistant_cardinal_sectors(self) -> None:
         """
@@ -782,10 +782,10 @@ class TestFindBestEquidistantSectors(TestCase):
         self.assertEqual(len(nodes), 4)
         for node in nodes:
             self.assertEqual(len(node), 1)
-        self.assertEqual(angle_delta(nodes[0][0], nodes[1][0]), 90)
-        self.assertEqual(angle_delta(nodes[1][0], nodes[2][0]), 90)
-        self.assertEqual(angle_delta(nodes[2][0], nodes[3][0]), 90)
-        self.assertEqual(angle_delta(nodes[3][0], nodes[0][0]), 90)
+        self.assertEqual(abs(angle_delta(nodes[0][0], nodes[1][0])), 90)
+        self.assertEqual(abs(angle_delta(nodes[1][0], nodes[2][0])), 90)
+        self.assertEqual(abs(angle_delta(nodes[2][0], nodes[3][0])), 90)
+        self.assertEqual(abs(angle_delta(nodes[3][0], nodes[0][0])), 90)
 
         # Each sector should be approximately aligned with each link
         for i in range(4):
@@ -838,10 +838,10 @@ class TestFindBestEquidistantSectors(TestCase):
         self.assertEqual(len(nodes), 4)
         for node in nodes:
             self.assertEqual(len(node), 1)
-        self.assertEqual(angle_delta(nodes[0][0], nodes[1][0]), 90)
-        self.assertEqual(angle_delta(nodes[1][0], nodes[2][0]), 90)
-        self.assertEqual(angle_delta(nodes[2][0], nodes[3][0]), 90)
-        self.assertEqual(angle_delta(nodes[3][0], nodes[0][0]), 90)
+        self.assertEqual(abs(angle_delta(nodes[0][0], nodes[1][0])), 90)
+        self.assertEqual(abs(angle_delta(nodes[1][0], nodes[2][0])), 90)
+        self.assertEqual(abs(angle_delta(nodes[2][0], nodes[3][0])), 90)
+        self.assertEqual(abs(angle_delta(nodes[3][0], nodes[0][0])), 90)
 
         # Test with 2 nodes each with 2 sectors
         nodes = find_best_equidistant_sectors(
@@ -855,13 +855,15 @@ class TestFindBestEquidistantSectors(TestCase):
         self.assertEqual(len(nodes), 2)
         for node in nodes:
             self.assertEqual(len(node), 2)
-        self.assertEqual(angle_delta(nodes[0][0], nodes[0][1]), scan_range)
+        self.assertEqual(abs(angle_delta(nodes[0][0], nodes[0][1])), scan_range)
         self.assertEqual(
-            angle_delta(nodes[0][1], nodes[1][0]), (360 - 2 * scan_range) / 2
+            abs(angle_delta(nodes[0][1], nodes[1][0])),
+            (360 - 2 * scan_range) / 2,
         )
-        self.assertEqual(angle_delta(nodes[1][0], nodes[1][1]), scan_range)
+        self.assertEqual(abs(angle_delta(nodes[1][0], nodes[1][1])), scan_range)
         self.assertEqual(
-            angle_delta(nodes[1][1], nodes[0][0]), (360 - 2 * scan_range) / 2
+            abs(angle_delta(nodes[1][1], nodes[0][0])),
+            (360 - 2 * scan_range) / 2,
         )
 
         # Test with 1 node with 1 sector
@@ -890,9 +892,9 @@ class TestFindBestEquidistantSectors(TestCase):
         self.assertEqual(len(nodes), 3)
         for node in nodes:
             self.assertEqual(len(node), 1)
-        self.assertEqual(angle_delta(nodes[0][0], nodes[1][0]), scan_range)
-        self.assertEqual(angle_delta(nodes[1][0], nodes[2][0]), scan_range)
-        self.assertEqual(angle_delta(nodes[2][0], nodes[0][0]), scan_range)
+        self.assertEqual(abs(angle_delta(nodes[0][0], nodes[1][0])), scan_range)
+        self.assertEqual(abs(angle_delta(nodes[1][0], nodes[2][0])), scan_range)
+        self.assertEqual(abs(angle_delta(nodes[2][0], nodes[0][0])), scan_range)
 
         scan_range = 360
         nodes = find_best_equidistant_sectors(
@@ -987,7 +989,7 @@ class TestSimpleFindBestSectors(TestCase):
         for node in nodes:
             self.assertEqual(len(node), 1)
         self.assertGreaterEqual(
-            angle_delta(nodes[0][0], nodes[1][0]), scan_range
+            abs(angle_delta(nodes[0][0], nodes[1][0])), scan_range
         )
 
     def test_find_cardinal_sectors(self) -> None:
@@ -1047,16 +1049,16 @@ class TestSimpleFindBestSectors(TestCase):
         for node in nodes:
             self.assertEqual(len(node), 1)
         self.assertGreaterEqual(
-            angle_delta(nodes[0][0], nodes[1][0]), scan_range
+            abs(angle_delta(nodes[0][0], nodes[1][0])), scan_range
         )
         self.assertGreaterEqual(
-            angle_delta(nodes[1][0], nodes[2][0]), scan_range
+            abs(angle_delta(nodes[1][0], nodes[2][0])), scan_range
         )
         self.assertGreaterEqual(
-            angle_delta(nodes[2][0], nodes[3][0]), scan_range
+            abs(angle_delta(nodes[2][0], nodes[3][0])), scan_range
         )
         self.assertGreaterEqual(
-            angle_delta(nodes[3][0], nodes[0][0]), scan_range
+            abs(angle_delta(nodes[3][0], nodes[0][0])), scan_range
         )
 
         # Each sector should be approximately aligned with each link
@@ -1118,16 +1120,16 @@ class TestSimpleFindBestSectors(TestCase):
         for node in nodes:
             self.assertEqual(len(node), 1)
         self.assertGreaterEqual(
-            angle_delta(nodes[0][0], nodes[1][0]), scan_range
+            abs(angle_delta(nodes[0][0], nodes[1][0])), scan_range
         )
         self.assertGreaterEqual(
-            angle_delta(nodes[1][0], nodes[2][0]), scan_range
+            abs(angle_delta(nodes[1][0], nodes[2][0])), scan_range
         )
         self.assertGreaterEqual(
-            angle_delta(nodes[2][0], nodes[3][0]), scan_range
+            abs(angle_delta(nodes[2][0], nodes[3][0])), scan_range
         )
         self.assertGreaterEqual(
-            angle_delta(nodes[3][0], nodes[0][0]), scan_range
+            abs(angle_delta(nodes[3][0], nodes[0][0])), scan_range
         )
 
         # Test with 2 nodes each with 2 sectors
@@ -1149,13 +1151,13 @@ class TestSimpleFindBestSectors(TestCase):
         self.assertEqual(len(nodes), 2)
         for node in nodes:
             self.assertEqual(len(node), 2)
-        self.assertEqual(angle_delta(nodes[0][0], nodes[0][1]), scan_range)
+        self.assertEqual(abs(angle_delta(nodes[0][0], nodes[0][1])), scan_range)
         self.assertGreaterEqual(
-            angle_delta(nodes[0][1], nodes[1][0]), scan_range
+            abs(angle_delta(nodes[0][1], nodes[1][0])), scan_range
         )
-        self.assertEqual(angle_delta(nodes[1][0], nodes[1][1]), scan_range)
+        self.assertEqual(abs(angle_delta(nodes[1][0], nodes[1][1])), scan_range)
         self.assertGreaterEqual(
-            angle_delta(nodes[1][1], nodes[0][0]), scan_range
+            abs(angle_delta(nodes[1][1], nodes[0][0])), scan_range
         )
 
         # Test with 1 node with 1 sector
@@ -1198,9 +1200,9 @@ class TestSimpleFindBestSectors(TestCase):
         self.assertEqual(len(nodes), 3)
         for node in nodes:
             self.assertEqual(len(node), 1)
-        self.assertEqual(angle_delta(nodes[0][0], nodes[1][0]), scan_range)
-        self.assertEqual(angle_delta(nodes[1][0], nodes[2][0]), scan_range)
-        self.assertEqual(angle_delta(nodes[2][0], nodes[0][0]), scan_range)
+        self.assertEqual(abs(angle_delta(nodes[0][0], nodes[1][0])), scan_range)
+        self.assertEqual(abs(angle_delta(nodes[1][0], nodes[2][0])), scan_range)
+        self.assertEqual(abs(angle_delta(nodes[2][0], nodes[0][0])), scan_range)
 
         scan_range = 360
         nodes = find_best_sectors(

--- a/terragraph_planner/optimization/topology_interference.py
+++ b/terragraph_planner/optimization/topology_interference.py
@@ -51,7 +51,11 @@ def compute_link_interference(
             continue
 
         net_gain = _compute_link_interference_net_gain(
-            link, none_throws(link.tx_dev), none_throws(link.rx_dev)
+            interfering_path=link,
+            tx_dev=none_throws(link.tx_dev),
+            rx_dev=none_throws(link.rx_dev),
+            tx_el_dev=link.el_dev,
+            rx_el_dev=-link.el_dev,
         )
 
         # Use max Tx power without backoff to preserve worst-case interference
@@ -72,6 +76,8 @@ def _compute_link_interference_net_gain(
     interfering_path: Link,
     tx_dev: float,
     rx_dev: float,
+    tx_el_dev: float,
+    rx_el_dev: float,
 ) -> float:
     """
     Compute the net gain of a tx interfering link on a rx interfered link
@@ -97,7 +103,8 @@ def _compute_link_interference_net_gain(
         rx_radio_pattern_data=rx_sector_params.antenna_pattern_data,
         tx_deviation=tx_dev,
         rx_deviation=rx_dev,
-        el_deviation=interfering_path.el_dev,
+        tx_el_deviation=tx_el_dev,
+        rx_el_deviation=rx_el_dev,
     )
 
 
@@ -326,8 +333,18 @@ def _calculate_net_gain_on_rx_links(
                 none_throws(interfering_path.rx_dev),
                 none_throws(rx_interfered_link.rx_dev),
             )
+            tx_el_dev = angle_delta(
+                interfering_path.el_dev, tx_interfering_link.el_dev
+            )
+            rx_el_dev = -angle_delta(
+                interfering_path.el_dev, rx_interfered_link.el_dev
+            )
             net_gain = _compute_link_interference_net_gain(
-                interfering_path, tx_dev, rx_dev
+                interfering_path=interfering_path,
+                tx_dev=tx_dev,
+                rx_dev=rx_dev,
+                tx_el_dev=tx_el_dev,
+                rx_el_dev=rx_el_dev,
             )
 
             link_net_gain_map.setdefault(

--- a/terragraph_planner/optimization/topology_interference.py
+++ b/terragraph_planner/optimization/topology_interference.py
@@ -319,12 +319,12 @@ def _calculate_net_gain_on_rx_links(
 
             # Calculate net gain using the angle between the links
             tx_dev = angle_delta(
-                none_throws(tx_interfering_link.tx_dev),
                 none_throws(interfering_path.tx_dev),
+                none_throws(tx_interfering_link.tx_dev),
             )
             rx_dev = angle_delta(
-                none_throws(rx_interfered_link.rx_dev),
                 none_throws(interfering_path.rx_dev),
+                none_throws(rx_interfered_link.rx_dev),
             )
             net_gain = _compute_link_interference_net_gain(
                 interfering_path, tx_dev, rx_dev

--- a/terragraph_planner/optimization/topology_preparation.py
+++ b/terragraph_planner/optimization/topology_preparation.py
@@ -331,7 +331,9 @@ def add_sectors_to_links(
         best_sector_from = None
         for sector_from_id in sectors_for_sites.get(site_from.site_id, []):
             sector_from = topology.sectors[sector_from_id]
-            delta_from = angle_delta(sector_from.ant_azimuth, bearing_from_to)
+            delta_from = abs(
+                angle_delta(sector_from.ant_azimuth, bearing_from_to)
+            )
             if delta_from < min_delta_from:
                 min_delta_from = delta_from
                 best_sector_from = sector_from
@@ -339,7 +341,7 @@ def add_sectors_to_links(
         best_sector_to = None
         for sector_to_id in sectors_for_sites.get(site_to.site_id, []):
             sector_to = topology.sectors[sector_to_id]
-            delta_to = angle_delta(sector_to.ant_azimuth, bearing_to_from)
+            delta_to = abs(angle_delta(sector_to.ant_azimuth, bearing_to_from))
             if delta_to < min_delta_to:
                 min_delta_to = delta_to
                 best_sector_to = sector_to
@@ -443,8 +445,8 @@ def validate_site_sectors(sectors: List[Sector]) -> None:
     if number_of_sectors_per_node > 1:
         for azimuths in sector_azimuths.values():
             for i in range(len(azimuths) - 1):
-                angle_diff = angle_delta(
-                    azimuths[i], azimuths[(i + 1) % len(azimuths)]
+                angle_diff = abs(
+                    angle_delta(azimuths[i], azimuths[(i + 1) % len(azimuths)])
                 )
                 planner_assert(
                     abs(angle_diff - horizontal_scan_range)
@@ -470,10 +472,10 @@ def validate_site_sectors(sectors: List[Sector]) -> None:
         for other_node_id, other_azimuths in sector_azimuths.items():
             if node_id == other_node_id:
                 continue
-            angle_diff1 = angle_delta(azimuths[0], other_azimuths[0])
-            angle_diff2 = angle_delta(azimuths[-1], other_azimuths[0])
-            angle_diff3 = angle_delta(azimuths[0], other_azimuths[-1])
-            angle_diff4 = angle_delta(azimuths[-1], other_azimuths[-1])
+            angle_diff1 = abs(angle_delta(azimuths[0], other_azimuths[0]))
+            angle_diff2 = abs(angle_delta(azimuths[-1], other_azimuths[0]))
+            angle_diff3 = abs(angle_delta(azimuths[0], other_azimuths[-1]))
+            angle_diff4 = abs(angle_delta(azimuths[-1], other_azimuths[-1]))
             min_angle_diff = min(
                 angle_diff1, angle_diff2, angle_diff3, angle_diff4
             )
@@ -510,7 +512,7 @@ def validate_link_sectors(
         link.tx_site.device.sector_params.horizontal_scan_range
     )
     planner_assert(
-        none_throws(link.tx_dev)
+        abs(none_throws(link.tx_dev))
         < tx_horizontal_scan_range / 2 + SECTOR_LINK_ANGLE_TOLERANCE,
         "Link is not within the horizontal scan range of the connected tx sector",
         OptimizerException,
@@ -524,7 +526,7 @@ def validate_link_sectors(
         link.rx_site.device.sector_params.horizontal_scan_range
     )
     planner_assert(
-        none_throws(link.rx_dev)
+        abs(none_throws(link.rx_dev))
         < rx_horizontal_scan_range / 2 + SECTOR_LINK_ANGLE_TOLERANCE,
         "Link is not within the horizontal scan range of the connected rx sector",
         OptimizerException,


### PR DESCRIPTION
## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

## Description

Tx and Rx deviation should have +/- sign.

Use negative el dev in rx antenna gain and use differences between interfering path and tx/rx link el devs in interference calculation

## Test Plan

Updated unit tests