### PR TITLE
Reporting Unit Tests with Manual Optimization

### DIFF
--- a/docs/runbook/Quick_Start.md
+++ b/docs/runbook/Quick_Start.md
@@ -61,8 +61,8 @@ Run the tests to check if the package is correctly installed.
 python3 -m unittest discover terragraph_planner -b
 ```
 
-> Using different versions of 3rd party dependencies than the ones specified
-in the requirements file can lead to test failure; this does **not** mean the
+> Using different versions of 3rd party dependencies from the ones specified
+in the requirements file can lead to test failure; this does **NOT** mean the
 optimized plan quality is degraded.
 
 ## Run a Plan

--- a/docs/runbook/Quick_Start.md
+++ b/docs/runbook/Quick_Start.md
@@ -61,6 +61,10 @@ Run the tests to check if the package is correctly installed.
 python3 -m unittest discover terragraph_planner -b
 ```
 
+> Using different versions of 3rd party dependencies than the ones specified
+in the requirements file can lead to test failure; this does **not** mean the
+optimized plan quality is degraded.
+
 ## Run a Plan
 
 ### Configuration File

--- a/terragraph_planner/optimization/test/test_topology_report.py
+++ b/terragraph_planner/optimization/test/test_topology_report.py
@@ -8,6 +8,10 @@ from unittest import TestCase
 from pyre_extensions import none_throws
 
 from terragraph_planner.common.configuration.configs import OptimizerParams
+from terragraph_planner.common.configuration.enums import (
+    PolarityType,
+    StatusType,
+)
 from terragraph_planner.common.data_io.data_key import (
     LinkKey,
     SectorKey,
@@ -20,9 +24,6 @@ from terragraph_planner.common.topology_models.test.helper import (
     square_topology_with_cns,
 )
 from terragraph_planner.optimization.structs import Capex, TopologyCounts
-from terragraph_planner.optimization.topology_optimization import (
-    optimize_topology,
-)
 from terragraph_planner.optimization.topology_report import analyze
 
 
@@ -32,13 +33,41 @@ class TestTopologyReport(TestCase):
             device_list=[DEFAULT_DN_DEVICE, DEFAULT_CN_DEVICE]
         )
         topology = square_topology()
-        optimize_topology(topology, params)
+
+        # Manually generate an optimized topology
+        even_sites = {"DN1", "DN4", "POP5"}
+        for site_id, site in topology.sites.items():
+            site.status_type = StatusType.PROPOSED
+            if site_id in even_sites:
+                site.polarity = PolarityType.EVEN
+            else:
+                site.polarity = PolarityType.ODD
+        for sector in topology.sectors.values():
+            sector.status_type = StatusType.PROPOSED
+            sector.channel = 0
+        proposed_links = {
+            "DN1-DN2",
+            "DN2-DN1",
+            "DN1-POP5",
+            "POP5-DN1",
+            "DN2-POP6",
+            "POP6-DN2",
+            "DN3-DN4",
+            "DN3-POP6",
+            "POP6-DN3",
+            "DN4-DN3",
+            "DN4-POP5",
+            "POP5-DN4",
+        }
+        for link_id in proposed_links:
+            topology.links[link_id].status_type = StatusType.PROPOSED
+
         result = analyze(topology, params)
 
         result_outgoing_flows = result.site_df[
             SiteKey.OUTGOING_FLOW.value.output_name
         ].to_list()
-        expected_outgoing_flows = [0.6, 0, 0, 0.6, 3.6, 3.6]
+        expected_outgoing_flows = [0.0, 0.0, 0.9, 0.0, 1.8, 3.6]
         for i in range(len(result_outgoing_flows)):
             self.assertAlmostEqual(
                 result_outgoing_flows[i], expected_outgoing_flows[i], 6
@@ -46,7 +75,7 @@ class TestTopologyReport(TestCase):
         result_incoming_flows = result.site_df[
             SiteKey.INCOMING_FLOW.value.output_name
         ].to_list()
-        expected_incoming_flows = [1.8, 2.4, 2.4, 1.8, 0.0, 0.0]
+        expected_incoming_flows = [0.9, 1.8, 1.8, 1.8, 0.0, 0.0]
         for i in range(len(result_incoming_flows)):
             self.assertAlmostEqual(
                 result_incoming_flows[i], expected_incoming_flows[i], 6
@@ -60,22 +89,22 @@ class TestTopologyReport(TestCase):
             LinkKey.PROPOSED_FLOW.value.output_name
         ].to_list()
         expected_proposed_flows = [
-            0.6,
             0.0,
             0.0,
             0.0,
             0.0,
             0.0,
             0.0,
+            0.9,
             0.0,
+            0.9,
             0.0,
-            0.0,
-            0.6,
+            0.9,
             0.0,
             1.8,
+            0.0,
             1.8,
-            1.8,
-            1.8,
+            0.0,
         ]
         for i in range(len(result_proposed_flows)):
             self.assertAlmostEqual(
@@ -83,11 +112,11 @@ class TestTopologyReport(TestCase):
             )
         self.assertEqual(
             result.sector_df[SectorKey.CHANNEL.value.output_name].to_list(),
-            ["0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0"],
+            ["0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0"],
         )
         self.assertEqual(
             result.metrics.capex,
-            Capex(total_capex=12000.0, proposed_capex=12000.0),
+            Capex(total_capex=11750.0, proposed_capex=11750.0),
         )
         self.assertEqual(
             result.metrics.counts,
@@ -106,16 +135,16 @@ class TestTopologyReport(TestCase):
                 active_demand_connected_cn_sites=0,
                 active_demand_connected_dn_sites=4,
                 active_demand_connected_pop_sites=0,
-                active_nodes=12,
-                total_nodes=12,
-                active_dn_nodes=12,
-                total_dn_nodes=12,
+                active_nodes=11,
+                total_nodes=11,
+                active_dn_nodes=11,
+                total_dn_nodes=11,
                 active_cn_nodes=0,
                 total_cn_nodes=0,
-                active_sectors=12,
-                total_sectors=12,
+                active_sectors=11,
+                total_sectors=11,
                 active_dn_sectors_on_dns=8,
-                active_dn_sectors_on_pops=4,
+                active_dn_sectors_on_pops=3,
                 active_cn_sectors=0,
                 active_backhaul_links=6,
                 total_backhaul_links=8,
@@ -127,18 +156,18 @@ class TestTopologyReport(TestCase):
         )
         self.assertIsNotNone(result.metrics.flow_metrics)
         flow_metrics = none_throws(result.metrics.flow_metrics)
-        self.assertAlmostEqual(flow_metrics.total_bandwidth, 7.2, 6)
+        self.assertAlmostEqual(flow_metrics.total_bandwidth, 5.4, 6)
         self.assertAlmostEqual(
-            flow_metrics.minimum_bandwdith_for_connected_demand, 1.2, 6
+            flow_metrics.minimum_bandwdith_for_connected_demand, 0.9, 6
         )
         self.assertAlmostEqual(
-            flow_metrics.link_capacity_utilization.avg, 77.777778, 6
+            flow_metrics.link_capacity_utilization.avg, 58.333333, 6
         )
         self.assertAlmostEqual(
             flow_metrics.link_capacity_utilization.max, 100.0, 6
         )
         self.assertAlmostEqual(
-            flow_metrics.link_capacity_utilization.min, 33.333333, 6
+            flow_metrics.link_capacity_utilization.min, 0.0, 6
         )
 
     def test_square_topology_with_cns(self) -> None:
@@ -146,13 +175,42 @@ class TestTopologyReport(TestCase):
             device_list=[DEFAULT_DN_DEVICE, DEFAULT_CN_DEVICE]
         )
         topology = square_topology_with_cns()
-        optimize_topology(topology, params)
+
+        # Manually generate an optimized topology
+        proposed_sites = {
+            "DN3": PolarityType.EVEN,
+            "DN4": PolarityType.ODD,
+            "POP5": PolarityType.EVEN,
+            "POP6": PolarityType.ODD,
+            "CN7": PolarityType.UNASSIGNED,
+            "CN8": PolarityType.UNASSIGNED,
+        }
+        for site_id, polarity in proposed_sites.items():
+            topology.sites[site_id].status_type = StatusType.PROPOSED
+            topology.sites[site_id].polarity = polarity
+        for sector in topology.sectors.values():
+            if sector.site.site_id in proposed_sites:
+                sector.status_type = StatusType.PROPOSED
+                sector.channel = 0
+        proposed_links = {
+            "DN3-DN4",
+            "DN4-DN3",
+            "DN3-POP6",
+            "POP6-DN3",
+            "DN4-POP5",
+            "POP5-DN4",
+            "DN4-CN7",
+            "DN4-CN8",
+        }
+        for link_id in proposed_links:
+            topology.links[link_id].status_type = StatusType.PROPOSED
+
         result = analyze(topology, params)
 
         result_outgoing_flows = result.site_df[
             SiteKey.OUTGOING_FLOW.value.output_name
         ].to_list()
-        expected_outgoing_flows = [0.0, 0.0, 0.0, 0.0, 0.0, 1.8, 1.8, 0.0]
+        expected_outgoing_flows = [0.0, 0.0, 0.0, 1.8, 1.8, 0.0, 0.0, 0.0]
         for i in range(len(result_outgoing_flows)):
             self.assertAlmostEqual(
                 result_outgoing_flows[i], expected_outgoing_flows[i], 6
@@ -160,14 +218,14 @@ class TestTopologyReport(TestCase):
         result_incoming_flows = result.site_df[
             SiteKey.INCOMING_FLOW.value.output_name
         ].to_list()
-        expected_incoming_flows = [0.9, 0.9, 0.0, 0.0, 0.0, 1.8, 0.0, 0.0]
+        expected_incoming_flows = [0.0, 0.0, 0.0, 1.8, 0.0, 0.0, 0.9, 0.9]
         for i in range(len(result_incoming_flows)):
             self.assertAlmostEqual(
                 result_incoming_flows[i], expected_incoming_flows[i], 6
             )
         self.assertEqual(
             result.site_df[SiteKey.BREAKDOWNS.value.output_name].to_list(),
-            [0, 0, 0, 0, 0, 2, 0, 0],
+            [0, 0, 0, 2, 0, 0, 0, 0],
         )
 
         result_proposed_flows = result.link_df[
@@ -183,15 +241,15 @@ class TestTopologyReport(TestCase):
             0.0,
             0.0,
             0.0,
-            0.9,
-            0.9,
-            0.0,
-            0.0,
-            0.0,
             0.0,
             1.8,
             0.0,
             0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.9,
+            0.9,
         ]
         for i in range(len(result_proposed_flows)):
             self.assertAlmostEqual(
@@ -199,11 +257,11 @@ class TestTopologyReport(TestCase):
             )
         self.assertEqual(
             result.sector_df[SectorKey.CHANNEL.value.output_name].to_list(),
-            ["0", "0", "0", "0", "0", "0", "0", "0"],
+            ["0", "0", "0", "0", "0", "0", "0", "0", "0"],
         )
         self.assertEqual(
             result.metrics.capex,
-            Capex(total_capex=10800.0, proposed_capex=10800.0),
+            Capex(total_capex=11050.0, proposed_capex=11050.0),
         )
         self.assertEqual(
             result.metrics.counts,
@@ -222,16 +280,16 @@ class TestTopologyReport(TestCase):
                 active_demand_connected_cn_sites=2,
                 active_demand_connected_dn_sites=0,
                 active_demand_connected_pop_sites=0,
-                active_nodes=8,
-                total_nodes=12,
-                active_dn_nodes=6,
-                total_dn_nodes=10,
+                active_nodes=9,
+                total_nodes=13,
+                active_dn_nodes=7,
+                total_dn_nodes=11,
                 active_cn_nodes=2,
                 total_cn_nodes=2,
-                active_sectors=8,
-                total_sectors=12,
+                active_sectors=9,
+                total_sectors=13,
                 active_dn_sectors_on_dns=4,
-                active_dn_sectors_on_pops=2,
+                active_dn_sectors_on_pops=3,
                 active_cn_sectors=2,
                 active_backhaul_links=3,
                 total_backhaul_links=8,


### PR DESCRIPTION
## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

## Description

Remove network optimization from reporting unit tests. Instead, manually generate proposed topology.

Note: manually generated topology comes from the optimized output; however, readjust_sectors_post_opt is not called, so some reporting values change.

With this change, the unit tests pass for both Xpress v8.13.0 and v8.14.2

## Test Plan

Ran reporting tests with both Xpress versions.