### PR TITLE
CN Tilt

### DIFF
--- a/terragraph_planner/common/rf/link_budget_calculator.py
+++ b/terragraph_planner/common/rf/link_budget_calculator.py
@@ -558,7 +558,8 @@ def fspl_based_estimation(
     mcs_snr_mbps_map: List[MCSMap],
     tx_deviation: float,
     rx_deviation: float,
-    el_deviation: float,
+    tx_el_deviation: float,
+    rx_el_deviation: float,
     tx_scan_pattern_data: Optional[ScanPatternData],
     rx_scan_pattern_data: Optional[ScanPatternData],
 ) -> LinkBudgetMeasurements:
@@ -567,7 +568,8 @@ def fspl_based_estimation(
     @param distance: The distance between two sites, i.e. the length of the link.
     @param tx_deviation: The horizontal deviation between tx sector and the link.
     @param rx_deviation: The horizontal deviation between rx sector and the link.
-    @param el_deviation: The elevation deviation of the link.
+    @param tx_el_deviation: The elevation deviation of the link in the tx direction.
+    @param rx_el_deviation: The elevation deviation of the link in the rx direction.
     @param max_tx_power: The maximum power of the transmitter site.
     @param tx_sector_params: The list of parameters that has tx radio related specifications
     @param rx_sector_params: The list of parameters that has rx radio related specifications
@@ -585,8 +587,8 @@ def fspl_based_estimation(
         rx_radio_pattern_data=rx_scan_pattern_data,
         tx_deviation=tx_deviation,
         rx_deviation=rx_deviation,
-        tx_el_deviation=el_deviation,
-        rx_el_deviation=-el_deviation,
+        tx_el_deviation=tx_el_deviation,
+        rx_el_deviation=rx_el_deviation,
     )
     np_dbm = get_noise_power(rx_sector_params)
     link_budget = get_measurements_from_tx_power(

--- a/terragraph_planner/common/rf/test/test_link_budget_calculator.py
+++ b/terragraph_planner/common/rf/test/test_link_budget_calculator.py
@@ -672,6 +672,7 @@ class TestFSPLBasedEstimation(unittest.TestCase):
                 0,
                 0,
                 0,
+                0,
                 None,
                 None,
             )

--- a/terragraph_planner/los/helper.py
+++ b/terragraph_planner/los/helper.py
@@ -471,7 +471,8 @@ def search_max_los_dist_based_on_capacity(
             mcs_snr_mbps_map=mcs_snr_mbps_map,
             tx_deviation=0.0,
             rx_deviation=0.0,
-            el_deviation=0.0,
+            tx_el_deviation=0.0,
+            rx_el_deviation=0.0,
             tx_scan_pattern_data=None,
             rx_scan_pattern_data=None,
         )
@@ -490,7 +491,8 @@ def search_max_los_dist_based_on_capacity(
         mcs_snr_mbps_map=mcs_snr_mbps_map,
         tx_deviation=0.0,
         rx_deviation=0.0,
-        el_deviation=0.0,
+        tx_el_deviation=0.0,
+        rx_el_deviation=0.0,
         tx_scan_pattern_data=None,
         rx_scan_pattern_data=None,
     )

--- a/terragraph_planner/los/test/test_helper.py
+++ b/terragraph_planner/los/test/test_helper.py
@@ -67,7 +67,8 @@ def mock_fspl_based_estimation(
     mcs_snr_mbps_map: List[MCSMap],
     tx_deviation: float,
     rx_deviation: float,
-    el_deviation: float,
+    tx_el_deviation: float,
+    rx_el_deviation: float,
     tx_scan_pattern_data: Optional[ScanPatternData],
     rx_scan_pattern_data: Optional[ScanPatternData],
 ) -> LinkBudgetMeasurements:

--- a/terragraph_planner/optimization/topology_interference.py
+++ b/terragraph_planner/optimization/topology_interference.py
@@ -50,6 +50,16 @@ def compute_link_interference(
             ] = -math.inf
             continue
 
+        # The deviations should be the angle between the interfering path and
+        # the interference causing links (tx_el_dev) and the interfered on
+        # links (rx_el_dev). However, for a candidate topology prior to
+        # optimization, this can be very expensive to compute (all candidate
+        # links are considered, not just active ones). Instead, to accelerate
+        # computation, we assume that the interference causing and interered on
+        # links have the same horizontal/vertical azimuth as their sectors.
+        # Based on experimentation, this approximation has only a minor impact
+        # on the final plan quality and thus is justified due to improved run
+        # time.
         net_gain = _compute_link_interference_net_gain(
             interfering_path=link,
             tx_dev=none_throws(link.tx_dev),
@@ -83,16 +93,10 @@ def _compute_link_interference_net_gain(
     Compute the net gain of a tx interfering link on a rx interfered link
     using the actual deviations between those links and the interfering path.
 
-    The tx_dev is the horizontal deviation in tx direction (degrees) and the
-    rx_dev is the horizontal deviation in rx direction (degrees). Note: the
-    deviations could be the angle of the link to the boresight or the angle
-    between links depending on what is required in the computation; ideally
-    this should always be the angle between links, but this can be very
-    expensive to compute during pre-optimization (all candidate links are
-    considered, not just active ones) and, based on experimentaiton, does not
-    impact planning quality enough to justify.
+    The tx_dev/tx_el_dev is the horizontal/vertical deviation in the tx
+    direction (degrees) and the rx_dev/rx_el_dev is the horizontal/vertical
+    deviation in the rx direction (degrees).
     """
-
     tx_sector_params = interfering_path.tx_site.device.sector_params
     rx_sector_params = interfering_path.rx_site.device.sector_params
     return get_fspl_based_net_gain(

--- a/terragraph_planner/optimization/topology_preparation.py
+++ b/terragraph_planner/optimization/topology_preparation.py
@@ -102,7 +102,8 @@ def add_link_capacities_without_deviation(
             mcs_snr_mbps_map=mcs_snr_mbps_map,
             tx_deviation=0.0,
             rx_deviation=0.0,
-            el_deviation=0.0,
+            tx_el_deviation=0.0,
+            rx_el_deviation=0.0,
             tx_scan_pattern_data=None,
             rx_scan_pattern_data=None,
         )
@@ -148,7 +149,12 @@ def add_link_capacities_with_deviation(
             mcs_snr_mbps_map=mcs_snr_mbps_map,
             tx_deviation=none_throws(link.tx_dev),
             rx_deviation=none_throws(link.rx_dev),
-            el_deviation=link.el_dev,
+            tx_el_deviation=link.el_dev,
+            # CNs have mechanical tilt, so deviation is 0 (not quite right for
+            # inactive wireless access links, but this is ignored)
+            rx_el_deviation=-link.el_dev
+            if link.link_type != LinkType.WIRELESS_ACCESS
+            else 0,
             tx_scan_pattern_data=tx_sector_params.scan_pattern_data,
             rx_scan_pattern_data=rx_sector_params.scan_pattern_data,
         )


### PR DESCRIPTION
## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

## Description

CNs are mechanically tilted toward their serving DN. Update capacity calculation so that this is properly reflected (i.e., elevation deviation is 0 in this case).

Note: interference calcaultions are not impacted. Post-optimization, the angle is between links and sector orientation is not relevant. Pre-optimization, the interfering path deviations are used (a comment is added/updated for this).

Note: the capacity calculation for inactive CNs after optimization is slightly incorrect. It assumes 0 deviation although the CN is oriented toward a different DN. Because capacity calculations for inactive links is not that important, this issue is ignored.

## Test Plan

Unit Tests