### PR TITLE
Max Tx Power (Orientation Independent)

### DIFF
--- a/terragraph_planner/common/rf/link_budget_calculator.py
+++ b/terragraph_planner/common/rf/link_budget_calculator.py
@@ -360,7 +360,6 @@ def get_max_boresight_gain_from_pattern_file(
 
 def get_max_tx_power(
     tx_sector_params: SectorParams,
-    tx_radio_pattern_data: Optional[Union[AntennaPatternData, ScanPatternData]],
     max_eirp_dbm: Optional[float],
 ) -> float:
     """
@@ -368,24 +367,14 @@ def get_max_tx_power(
     """
     max_tx_power = tx_sector_params.maximum_tx_power
     if max_eirp_dbm is not None:
-        if tx_radio_pattern_data is not None and is_scan_pattern_data(
-            tx_radio_pattern_data
-        ):
-            tx_gain = get_max_boresight_gain_from_pattern_file(
-                cast(ScanPatternData, tx_radio_pattern_data)
-            )
-        else:
-            tx_gain = extract_gain_from_radio_pattern(
-                boresight_gain=tx_sector_params.antenna_boresight_gain,
-                diversity_gain=tx_sector_params.tx_diversity_gain,
-                radio_pattern_data=tx_radio_pattern_data,
-                az_deviation=0,
-                el_deviation=0,
-            )
+        max_tx_gain = (
+            tx_sector_params.antenna_boresight_gain
+            + tx_sector_params.tx_diversity_gain
+        )
         max_tx_power = float(
             min(
                 max_tx_power,
-                max_eirp_dbm - tx_gain,
+                max_eirp_dbm - max_tx_gain,
             ),
         )
     if tx_sector_params.minimum_tx_power is not None:

--- a/terragraph_planner/common/rf/link_budget_calculator.py
+++ b/terragraph_planner/common/rf/link_budget_calculator.py
@@ -367,9 +367,12 @@ def get_max_tx_power(
     """
     max_tx_power = tx_sector_params.maximum_tx_power
     if max_eirp_dbm is not None:
-        max_tx_gain = (
-            tx_sector_params.antenna_boresight_gain
-            + tx_sector_params.tx_diversity_gain
+        max_tx_gain = extract_gain_from_radio_pattern(
+            boresight_gain=tx_sector_params.antenna_boresight_gain,
+            diversity_gain=tx_sector_params.tx_diversity_gain,
+            radio_pattern_data=None,
+            az_deviation=0,
+            el_deviation=0,
         )
         max_tx_power = float(
             min(

--- a/terragraph_planner/los/helper.py
+++ b/terragraph_planner/los/helper.py
@@ -330,9 +330,7 @@ def get_max_los_dist_for_device_pairs(
     A dict mapping a pair of device SKUs to the max los distance.
     """
     device_to_max_tx_power: Dict[str, float] = {
-        device.device_sku: get_max_tx_power(
-            device.sector_params, None, max_eirp_dbm
-        )
+        device.device_sku: get_max_tx_power(device.sector_params, max_eirp_dbm)
         for device in device_list
     }
     device_pair_to_max_los_dist: Dict[Tuple[str, str], int] = {}

--- a/terragraph_planner/optimization/test/test_topology_interference.py
+++ b/terragraph_planner/optimization/test/test_topology_interference.py
@@ -140,7 +140,6 @@ class TestInterferenceComputation(TestCase):
             tx_sector_params = link.tx_site.device.sector_params
             link.tx_power = get_max_tx_power(
                 tx_sector_params=tx_sector_params,
-                tx_radio_pattern_data=tx_sector_params.antenna_pattern_data,
                 max_eirp_dbm=params.maximum_eirp,
             )
 
@@ -363,7 +362,6 @@ class TestInterferenceComputation(TestCase):
             tx_sector_params = link.tx_site.device.sector_params
             link.tx_power = get_max_tx_power(
                 tx_sector_params=tx_sector_params,
-                tx_radio_pattern_data=tx_sector_params.antenna_pattern_data,
                 max_eirp_dbm=params.maximum_eirp,
             )
 

--- a/terragraph_planner/optimization/topology_interference.py
+++ b/terragraph_planner/optimization/topology_interference.py
@@ -73,7 +73,6 @@ def compute_link_interference(
         tx_sector_params = link.tx_site.device.sector_params
         max_tx_power = get_max_tx_power(
             tx_sector_params=tx_sector_params,
-            tx_radio_pattern_data=tx_sector_params.antenna_pattern_data,
             max_eirp_dbm=maximum_eirp,
         )
         rsl_interference[

--- a/terragraph_planner/optimization/topology_operations.py
+++ b/terragraph_planner/optimization/topology_operations.py
@@ -524,7 +524,6 @@ def _get_max_tx_power_of_all_links(
         tx_data = topology.sites[link.tx_site.site_id].device
         max_tx_power[link_id] = get_max_tx_power(
             tx_sector_params=tx_data.sector_params,
-            tx_radio_pattern_data=tx_data.sector_params.antenna_pattern_data,
             max_eirp_dbm=max_eirp_dbm,
         )
     return max_tx_power

--- a/terragraph_planner/optimization/topology_preparation.py
+++ b/terragraph_planner/optimization/topology_preparation.py
@@ -91,7 +91,6 @@ def add_link_capacities_without_deviation(
 
         max_tx_power = get_max_tx_power(
             tx_sector_params=tx_sector_params,
-            tx_radio_pattern_data=None,
             max_eirp_dbm=params.maximum_eirp,
         )
         link.link_budget = fspl_based_estimation(
@@ -138,7 +137,6 @@ def add_link_capacities_with_deviation(
 
         max_tx_power = get_max_tx_power(
             tx_sector_params=tx_sector_params,
-            tx_radio_pattern_data=tx_sector_params.scan_pattern_data,
             max_eirp_dbm=params.maximum_eirp,
         )
         link.link_budget = fspl_based_estimation(


### PR DESCRIPTION
## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

## Description

Max tx power + gain <= max eirp

The current version has different values for gain depending on if capacity or interference is being calculated. This can create inconsistencies.

Technically, the tx power can be increased if there is scan loss. This would be an orientation-dependent max tx power. For now, we opt for a orientation-independent max tx power that simply takes the max gain (user supplied antenna boresight gain + diversity gain) and subtracts that from max eirp to bound the max tx power.

Making max tx power orientation-dependent can be a follow-up to this fix.

## Test Plan

Unit tests