### PR TITLE
Transmit Power Potpourri

### DIFF
--- a/terragraph_planner/common/rf/link_budget_calculator.py
+++ b/terragraph_planner/common/rf/link_budget_calculator.py
@@ -295,7 +295,7 @@ def get_fspl_based_net_gain(
     @param tx_deviation: Horizontal deviation from boresight in tx direction (degrees)
     @param rx_deviation: Horizontal deviation from boresight in rx direction (degrees)
     @param tx_el_deviation: Vertical deviation from horizontal plane in tx direction (degrees)
-    @param rx_el_deviation: Vertical deviation from horizontal plane rx rx direction (degrees)
+    @param rx_el_deviation: Vertical deviation from horizontal plane in rx direction (degrees)
     """
 
     # FSPL (dB) when link distance d (kms) and frequency (GHz) is given.

--- a/terragraph_planner/common/rf/link_budget_calculator.py
+++ b/terragraph_planner/common/rf/link_budget_calculator.py
@@ -501,44 +501,16 @@ def get_tx_power_from_rsl(rsl_dbm: float, net_gain_dbi: float) -> float:
     return rsl_dbm - net_gain_dbi
 
 
-def get_link_capacity_from_snr(
-    snr_dbm: float, mcs_snr_mbps_map: List[MCSMap]
-) -> Tuple[int, float]:
+def get_link_capacity_from_mcs(
+    mcs_level: int, mcs_snr_mbps_map: List[MCSMap]
+) -> float:
     """
-    Returns MCS and Mbps values given the signal-to-noise
-    (OR signal to interference + noise) ratio in dBm.
-
-    @param snr_dbm: the SNR or SINR value in dBm
-    @param mcs_snr_mbps_map: table of SNR thresholds and Mbps
-
-    returns MCS and the Mbps values
+    Returns Mbps values given the MCS level
     """
-    mcs_level = get_mcs_from_snr(snr_dbm, mcs_snr_mbps_map)
     mbps_value = [row.mbps for row in mcs_snr_mbps_map if row.mcs == mcs_level]
     if len(mbps_value) == 0:
-        return 0, 0.0
-    return mcs_level, mbps_to_gbps(mbps_value[0])
-
-
-def get_measurements_from_tx_power(
-    tx_power: float,
-    net_gain_dbi: float,
-    np_dbm: float,
-    mcs_snr_mbps_map: List[MCSMap],
-) -> LinkBudgetMeasurements:
-    """
-    Return MCS level and capacity given Tx power, gain and noise
-    """
-    rsl_dbm = get_fspl_based_rsl(tx_power, net_gain_dbi)
-    snr_dbm = get_snr(rsl_dbm, np_dbm)
-    mcs_level, capacity = get_link_capacity_from_snr(snr_dbm, mcs_snr_mbps_map)
-    return LinkBudgetMeasurements(
-        mcs_level=mcs_level,
-        rsl_dbm=rsl_dbm,
-        snr_dbm=snr_dbm,
-        capacity=capacity,
-        tx_power=tx_power,
-    )
+        return 0.0
+    return mbps_to_gbps(mbps_value[0])
 
 
 def fspl_based_estimation(
@@ -568,8 +540,21 @@ def fspl_based_estimation(
     @param tx_antenna_pattern: The antenna pattern for the tx radio.
     @param rx_antenna_pattern: The antenna pattern for the rx radio.
 
+    Note: the output tx power is the maximum allowed for the MCS class of the link.
+    Due to tx power backoff, this could result in a SNR/RSL that would place the link
+    into a higher MCS class. However, this function is primarily used to
+    - Compute capacity of a link for determining the max LOS distance (so tx power, SNR,
+      RSL do not matter)
+    - During pre-optimization setup for usage during interference modeling in the
+      optimization phase. There, the RSL values matter and we want these to be as high as
+      possible so as to not artifically lower the MCS class of a link when encountering
+      interference
+    - Prior to TPC where we do not want to artificially lower the MCS class of a link when
+      encountering interference. In that case, the TPC iteration will ensure that the final
+      tx power output is the minimal necessary to achieve the MCS class (i.e., this is simply
+      used to initialize the TPC iteration)
     """
-    # First compute link budget using maximum possible Tx power
+    # First compute link budget using maximum possible tx power
     net_gain_dbi = get_fspl_based_net_gain(
         dist_m=distance,
         tx_sector_params=tx_sector_params,
@@ -582,25 +567,36 @@ def fspl_based_estimation(
         rx_el_deviation=rx_el_deviation,
     )
     np_dbm = get_noise_power(rx_sector_params)
-    link_budget = get_measurements_from_tx_power(
-        tx_power=max_tx_power,
-        net_gain_dbi=net_gain_dbi,
-        np_dbm=np_dbm,
-        mcs_snr_mbps_map=mcs_snr_mbps_map,
-    )
-    # Adjust Tx power considering Tx power backoff
-    _, tx_power = adjust_tx_power_with_backoff(
-        mcs_level=link_budget.mcs_level,
+
+    rsl_dbm = get_fspl_based_rsl(max_tx_power, net_gain_dbi)
+    snr_dbm = get_snr(rsl_dbm, np_dbm)
+    mcs_level = get_mcs_from_snr(snr_dbm, mcs_snr_mbps_map)
+
+    # Adjust tx power considering tx power backoff, i.e., tx power for computed
+    # MCS level might exceed allowed tx power
+    mcs_level, _ = adjust_tx_power_with_backoff(
+        mcs_level=mcs_level,
         mcs_snr_mbps_map=mcs_snr_mbps_map,
         min_tx_power=tx_sector_params.minimum_tx_power,
         max_tx_power=max_tx_power,
         net_gain_dbi=net_gain_dbi,
         np_dbm=np_dbm,
     )
-    # Recalculate measurements with adjusted Tx power
-    return get_measurements_from_tx_power(
+    capacity = get_link_capacity_from_mcs(mcs_level, mcs_snr_mbps_map)
+
+    # Set tx power to maximum tx power allowed for that MCS level
+    tx_backoff = get_backoff_from_mcs(mcs_level, mcs_snr_mbps_map)
+    tx_power = max_tx_power - tx_backoff
+    # Due to tx power backoff, SNR could be high enough to merit higher MCS
+    # class. But doing so would violate the max allowed tx power, so the MCS
+    # class (and hence capacity) is artifically lowered
+    rsl_dbm = get_fspl_based_rsl(tx_power, net_gain_dbi)
+    snr_dbm = get_snr(rsl_dbm, np_dbm)
+
+    return LinkBudgetMeasurements(
+        mcs_level=mcs_level,
+        rsl_dbm=rsl_dbm,
+        snr_dbm=snr_dbm,
+        capacity=capacity,
         tx_power=tx_power,
-        net_gain_dbi=net_gain_dbi,
-        np_dbm=np_dbm,
-        mcs_snr_mbps_map=mcs_snr_mbps_map,
     )

--- a/terragraph_planner/common/rf/test/test_link_budget_calculator.py
+++ b/terragraph_planner/common/rf/test/test_link_budget_calculator.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import math
 import unittest
 
 from terragraph_planner.common.configuration.configs import SectorParams
@@ -21,7 +20,7 @@ from terragraph_planner.common.rf.link_budget_calculator import (
     fspl_based_estimation,
     get_fspl_based_net_gain,
     get_fspl_based_rsl,
-    get_link_capacity_from_snr,
+    get_link_capacity_from_mcs,
     get_max_boresight_gain_from_pattern_file,
     get_mcs_from_snr,
     get_net_gain,
@@ -450,10 +449,9 @@ class TestLinkTxPower(unittest.TestCase):
         ]
         for mcs, expected_capacity in test_data:
             snr_dbm = get_snr_from_mcs(mcs, DEFAULT_MCS_SNR_MBPS_MAP)
+            mcs_level = get_mcs_from_snr(snr_dbm, DEFAULT_MCS_SNR_MBPS_MAP)
             self.assertEqual(
-                get_link_capacity_from_snr(snr_dbm, DEFAULT_MCS_SNR_MBPS_MAP)[
-                    1
-                ],
+                get_link_capacity_from_mcs(mcs_level, DEFAULT_MCS_SNR_MBPS_MAP),
                 mhz_to_ghz(expected_capacity),
             )
 
@@ -555,110 +553,110 @@ class TestFSPLBasedEstimation(unittest.TestCase):
                 40,
                 LinkBudgetMeasurements(
                     mcs_level=10,
-                    rsl_dbm=-60,
-                    snr_dbm=14,
+                    rsl_dbm=-57.1,
+                    snr_dbm=16.9,
                     capacity=1.030,
-                    tx_power=11.1,
+                    tx_power=14.0,
                 ),
             ),
             (
                 50,
                 LinkBudgetMeasurements(
                     mcs_level=10,
-                    rsl_dbm=-60,
-                    snr_dbm=14,
+                    rsl_dbm=-59.3,
+                    snr_dbm=14.7,
                     capacity=1.030,
-                    tx_power=13.3,
+                    tx_power=14.0,
                 ),
             ),
             (
                 60,
                 LinkBudgetMeasurements(
                     mcs_level=9,
-                    rsl_dbm=-62,
-                    snr_dbm=12,
+                    rsl_dbm=-59.1,
+                    snr_dbm=14.9,
                     capacity=0.74125,
-                    tx_power=13.1,
+                    tx_power=16.0,
                 ),
             ),
             (
                 70,
                 LinkBudgetMeasurements(
                     mcs_level=9,
-                    rsl_dbm=-62,
-                    snr_dbm=12,
+                    rsl_dbm=-60.7,
+                    snr_dbm=13.3,
                     capacity=0.74125,
-                    tx_power=14.7,
+                    tx_power=16.0,
                 ),
             ),
             (
                 80,
                 LinkBudgetMeasurements(
                     mcs_level=8,
-                    rsl_dbm=-65,
-                    snr_dbm=9,
+                    rsl_dbm=-62.1,
+                    snr_dbm=11.9,
                     capacity=0.645,
-                    tx_power=13.1,
+                    tx_power=16.0,
                 ),
             ),
             (
                 90,
                 LinkBudgetMeasurements(
                     mcs_level=8,
-                    rsl_dbm=-65,
-                    snr_dbm=9,
+                    rsl_dbm=-63.4,
+                    snr_dbm=10.6,
                     capacity=0.645,
-                    tx_power=14.4,
+                    tx_power=16.0,
                 ),
             ),
             (
                 100,
                 LinkBudgetMeasurements(
                     mcs_level=8,
-                    rsl_dbm=-65,
-                    snr_dbm=9,
+                    rsl_dbm=-64.5,
+                    snr_dbm=9.5,
                     capacity=0.645,
-                    tx_power=15.5,
+                    tx_power=16.0,
                 ),
             ),
             (
                 125,
                 LinkBudgetMeasurements(
                     mcs_level=6,
-                    rsl_dbm=-68.5,
-                    snr_dbm=5.5,
+                    rsl_dbm=-67.1,
+                    snr_dbm=6.9,
                     capacity=0.260,
-                    tx_power=14.6,
+                    tx_power=16.0,
                 ),
             ),
             (
                 150,
                 LinkBudgetMeasurements(
                     mcs_level=4,
-                    rsl_dbm=-69.5,
-                    snr_dbm=4.5,
+                    rsl_dbm=-69.3,
+                    snr_dbm=4.7,
                     capacity=0.0675,
-                    tx_power=15.8,
+                    tx_power=16.0,
                 ),
             ),
             (
                 175,
                 LinkBudgetMeasurements(
                     mcs_level=0,
-                    rsl_dbm=-math.inf,
-                    snr_dbm=-math.inf,
+                    rsl_dbm=-71.3,
+                    snr_dbm=2.7,
                     capacity=0,
-                    tx_power=-math.inf,
+                    tx_power=16.0,
                 ),
             ),
             (
                 200,
                 LinkBudgetMeasurements(
                     mcs_level=0,
-                    rsl_dbm=-math.inf,
-                    snr_dbm=-math.inf,
+                    rsl_dbm=-73.1,
+                    snr_dbm=0.9,
                     capacity=0,
-                    tx_power=-math.inf,
+                    tx_power=16.0,
                 ),
             ),
         ]
@@ -679,8 +677,12 @@ class TestFSPLBasedEstimation(unittest.TestCase):
             self.assertEqual(
                 link_budget.mcs_level, expected_link_budget.mcs_level
             )
-            self.assertEqual(link_budget.rsl_dbm, expected_link_budget.rsl_dbm)
-            self.assertEqual(link_budget.snr_dbm, expected_link_budget.snr_dbm)
+            self.assertAlmostEqual(
+                link_budget.rsl_dbm, expected_link_budget.rsl_dbm, places=1
+            )
+            self.assertAlmostEqual(
+                link_budget.snr_dbm, expected_link_budget.snr_dbm, places=1
+            )
             self.assertEqual(
                 link_budget.capacity, expected_link_budget.capacity
             )

--- a/terragraph_planner/optimization/constants.py
+++ b/terragraph_planner/optimization/constants.py
@@ -9,10 +9,7 @@ BACKHAUL_LINK_TYPE_WEIGHT = 8  # Access link weight is 1
 COVERAGE_STEP_SIZE = 0.1  # coverage increment during min cost optimization
 COVERAGE_THRESHOLD = 0.5  # lower bound of coverage for min cost optimization
 EPSILON = 1e-5
-# interference converge threshold for link budget post-optimization, dBm
-LINK_BUDGET_CONVERGE_THRESHOLD = 3
-# maximum number of iterations in link budget post-optimization
-MAX_LINK_BUDGET_ITERATIONS = 10
+MAX_LINK_BUDGET_ITERATIONS = 10  # Max iterations for tx power iteration
 UNASSIGNED_CHANNEL = -1
 
 DEMAND = "DEMAND"

--- a/terragraph_planner/optimization/ilp_models/test/test_interference_optimization.py
+++ b/terragraph_planner/optimization/ilp_models/test/test_interference_optimization.py
@@ -160,6 +160,7 @@ class TestInterferenceOptimization(TestCase):
         """
         params = OptimizerParams(
             device_list=[DEFAULT_DN_DEVICE, DEFAULT_CN_DEVICE],
+            demand=1.8,  # Max demand that can be satisfied with 0 interference
         )
         topology = intersecting_links_topology(params)
 

--- a/terragraph_planner/optimization/test/test_topology_interference.py
+++ b/terragraph_planner/optimization/test/test_topology_interference.py
@@ -348,6 +348,7 @@ class TestInterferenceComputation(TestCase):
     def test_multi_channel_interference(self) -> None:
         params = OptimizerParams(
             device_list=[DEFAULT_DN_DEVICE, DEFAULT_CN_DEVICE],
+            demand=1.8,  # Max demand that can be satisfied with 0 interference
         )
         topology = intersecting_links_topology(params)
 

--- a/terragraph_planner/optimization/test/test_topology_preparation.py
+++ b/terragraph_planner/optimization/test/test_topology_preparation.py
@@ -91,14 +91,7 @@ class TestTopologyPreparation(TestCase):
         prepare_topology_for_optimization(
             topology,
             OptimizerParams(
-                device_list=[
-                    DeviceData(
-                        device_sku="Device_DN90",
-                        sector_params=SectorParams(horizontal_scan_range=90),
-                        number_of_nodes_per_site=4,
-                        device_type=DeviceType.DN,
-                    )
-                ]
+                device_list=[DEFAULT_DN_DEVICE, DEFAULT_CN_DEVICE],
             ),
         )
 

--- a/terragraph_planner/optimization/topology_operations.py
+++ b/terragraph_planner/optimization/topology_operations.py
@@ -35,7 +35,6 @@ from terragraph_planner.common.topology_models.topology import Topology
 from terragraph_planner.optimization.constants import (
     BACKHAUL_LINK_TYPE_WEIGHT,
     EPSILON,
-    MAX_LINK_BUDGET_ITERATIONS,
 )
 from terragraph_planner.optimization.structs import Capex
 from terragraph_planner.optimization.topology_interference import (
@@ -506,7 +505,7 @@ def compute_capex(topology: Topology, params: OptimizerParams) -> Capex:
 def update_link_caps_with_sinr(
     topology: Topology,
     params: OptimizerParams,
-    max_iterations: int = MAX_LINK_BUDGET_ITERATIONS,
+    max_iterations: int,
 ) -> None:
     """
     Prior to selecting a subset of active links, we compute link capacities

--- a/terragraph_planner/optimization/topology_report.py
+++ b/terragraph_planner/optimization/topology_report.py
@@ -35,6 +35,7 @@ from terragraph_planner.common.topology_models.topology import Topology
 from terragraph_planner.common.utils import current_system_params
 from terragraph_planner.optimization.constants import (
     EPSILON,
+    MAX_LINK_BUDGET_ITERATIONS,
     SUPERSOURCE,
     UNASSIGNED_CHANNEL,
 )
@@ -214,7 +215,7 @@ def get_routing_flow_solution(
     """
     Calculate maximum flow solution and active link utilization.
     """
-    update_link_caps_with_sinr(topology, params)
+    update_link_caps_with_sinr(topology, params, MAX_LINK_BUDGET_ITERATIONS)
     flow_solution = MaxFlowNetwork(topology, params).solve()
     if flow_solution is None:
         return None

--- a/terragraph_planner/optimization/topology_report.py
+++ b/terragraph_planner/optimization/topology_report.py
@@ -214,7 +214,7 @@ def get_routing_flow_solution(
     """
     Calculate maximum flow solution and active link utilization.
     """
-    update_link_caps_with_sinr(topology, params.maximum_eirp)
+    update_link_caps_with_sinr(topology, params)
     flow_solution = MaxFlowNetwork(topology, params).solve()
     if flow_solution is None:
         return None


### PR DESCRIPTION
## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

## Description

Various changes to handling of tx power throughout the codebase.

1. Link tx power when computing capacities is now max allowed by MCS class rather than min needed to support MCS class; for pre-optimization, using min needed for MCS class needlessly makes RSL lower for the Interference Minimization; for post-optimization, max allowed by MCS class is exactly the desired tx power to initialize the TPC iteration.
2. Compute link capacity (with deviation) in reporting stage rather than end of optimization stage; this way, reporting can be called without requiring link budgets to have already been computed.
3. Combine link capacity (with and without deviation) into a single function.
4. Change convergence criteria to tx power no longer changing in TPC rather than SINR=SNR which might not be possible.

## Test Plan

Updated various unit tests