### PR TITLE
Fix Deviation from Antenna Pattern Bug

### DIFF
--- a/terragraph_planner/common/rf/link_budget_calculator.py
+++ b/terragraph_planner/common/rf/link_budget_calculator.py
@@ -186,21 +186,20 @@ def extract_gain_from_radio_pattern(
     )
 
     # Convert deviation from (-180, 180] to [0, 360)
+    # Round value first so small negative number goes to 0 not 360
+    el_dev_360 = round(el_deviation)
     el_dev_360 = (
-        el_deviation
-        if el_deviation >= 0
-        else el_deviation + FULL_ROTATION_ANGLE
+        el_dev_360 if el_dev_360 >= 0 else el_dev_360 + int(FULL_ROTATION_ANGLE)
     )
+    az_dev_360 = round(az_deviation)
     az_dev_360 = (
-        az_deviation
-        if az_deviation >= 0
-        else az_deviation + FULL_ROTATION_ANGLE
+        az_dev_360 if az_dev_360 >= 0 else az_dev_360 + int(FULL_ROTATION_ANGLE)
     )
     el_gain = radio_pattern_data[none_throws(antenna_type)][EL_INDEX][
-        round(el_dev_360)
+        el_dev_360
     ]
     az_gain = radio_pattern_data[none_throws(antenna_type)][AZ_INDEX][
-        round(az_dev_360)
+        az_dev_360
     ]
     return boresight_gain + diversity_gain + el_gain + az_gain
 

--- a/terragraph_planner/common/rf/test/test_link_budget_calculator.py
+++ b/terragraph_planner/common/rf/test/test_link_budget_calculator.py
@@ -723,6 +723,11 @@ class TestAntennaPattern(unittest.TestCase):
         self.assertAlmostEqual(
             gain, 10.0 - 255.646229749276 - 31.9743585270337, 6
         )
+        # Verify small negative value gets rounded to 0 not 360
+        gain = extract_gain_from_radio_pattern(
+            boresight_gain, diversity_gain, pattern_data, -0.02, 0
+        )
+        self.assertAlmostEqual(gain, 10.0, 6)
 
 
 class TestScanPattern(unittest.TestCase):


### PR DESCRIPTION
## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

## Description

Fix bug in grabbing value from antenna pattern for small negative angles. Previously, they would be converted to a number just less than 360 and then rounded to 360 rather than converted to 0. This fixes that.

## Test Plan

Add unit test